### PR TITLE
error fix for running exmaple file with cuda device

### DIFF
--- a/vmas/simulator/environment.py
+++ b/vmas/simulator/environment.py
@@ -369,9 +369,9 @@ class Environment(TorchVectorizedObject):
                 idx += 1
 
         if aspect_ratio < 1:
-            cam_range = torch.tensor([VIEWER_MIN_SIZE, VIEWER_MIN_SIZE / aspect_ratio])
+            cam_range = torch.tensor([VIEWER_MIN_SIZE, VIEWER_MIN_SIZE / aspect_ratio],device=self.device)
         else:
-            cam_range = torch.tensor([VIEWER_MIN_SIZE * aspect_ratio, VIEWER_MIN_SIZE])
+            cam_range = torch.tensor([VIEWER_MIN_SIZE * aspect_ratio, VIEWER_MIN_SIZE],device=self.device)
 
         if shared_viewer:
             # zoom out to fit everyone


### PR DESCRIPTION
Hi, I tried to run the example file "use_vmas_env.py". 
However, when I modify the device "cpu" to "cuda", the error came out as:

Traceback (most recent call last):
  File "/home/keep9oing/VectorizedMultiAgentSimulator/examples/use_vmas_env.py", line 107, in <module>
    use_vmas_env(render=True)
  File "/home/keep9oing/VectorizedMultiAgentSimulator/examples/use_vmas_env.py", line 58, in use_vmas_env
    env.try_render_at(
  File "/home/keep9oing/VectorizedMultiAgentSimulator/vmas/simulator/environment.py", line 546, in try_render_at
    return self._env.render(
  File "/home/keep9oing/VectorizedMultiAgentSimulator/vmas/simulator/environment.py", line 392, in render
    viewer_size = torch.maximum(viewer_size_fit / cam_range, torch.tensor(1))
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!

The variable cam_range is allocated to the CPU, so I fixed the error with this commit. Please check it out.

Thanks for your great simulator.