### PR TITLE
Implement velocity controller (pid) for agent

### DIFF
--- a/vmas/scenarios/velocity_control.py
+++ b/vmas/scenarios/velocity_control.py
@@ -1,0 +1,57 @@
+#  Copyright (c) 2022.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+
+import torch
+
+from vmas import render_interactively
+from vmas.simulator.core import Agent, World
+from vmas.simulator.scenario import BaseScenario
+from vmas.simulator.velocity_controller import VelocityController
+
+
+class Scenario(BaseScenario):
+    def make_world(self, batch_dim: int, device: torch.device, **kwargs):
+        n_agents = kwargs.get("n_agents", 1)
+
+        # Make world
+        world = World(batch_dim, device, drag=0)
+        # Add agents
+        for i in range(n_agents):
+            # Constraint: all agents have same action range and multiplier
+            agent = Agent(
+                name=f"agent {i}", collide=True, u_range=1, u_multiplier=1, f_range=None
+            )
+            world.add_agent(agent)
+            agent.controller = VelocityController(agent, world.dt)
+
+        return world
+
+    def reset_world_at(self, env_index: int = None):
+        for agent in self.world.agents:
+            agent.set_pos(
+                torch.zeros(
+                    (1, self.world.dim_p)
+                    if env_index is not None
+                    else (self.world.batch_dim, self.world.dim_p),
+                    device=self.world.device,
+                    dtype=torch.float32,
+                ),
+                batch_index=env_index,
+            )
+
+    def process_action(self, agent: Agent):
+        agent.controller.process_force()
+
+    def reward(self, agent: Agent):
+        return torch.zeros(self.world.batch_dim, device=self.world.device)
+
+    def observation(self, agent: Agent):
+        return torch.cat(
+            [agent.state.pos, agent.state.vel],
+            dim=-1,
+        )
+
+
+if __name__ == "__main__":
+    render_interactively("velocity_control", control_two_agents=False, n_agents=1)

--- a/vmas/scenarios/velocity_control.py
+++ b/vmas/scenarios/velocity_control.py
@@ -13,9 +13,10 @@ from vmas.simulator.velocity_controller import VelocityController
 class Scenario(BaseScenario):
     def make_world(self, batch_dim: int, device: torch.device, **kwargs):
         n_agents = kwargs.get("n_agents", 1)
+        self.plot_grid = True
 
         # Make world
-        world = World(batch_dim, device, drag=0, linear_friction=0)
+        world = World(batch_dim, device, drag=0.25)
         # Add agents
         for i in range(n_agents):
             # Constraint: all agents have same action range and multiplier
@@ -29,7 +30,7 @@ class Scenario(BaseScenario):
             )
             world.add_agent(agent)
             agent.controller = VelocityController(
-                agent, world.dt, [1.5, 0.15, 0.01], "standard"
+                agent, world.dt, [1, 0.1, 0.01], "standard"
             )
         goal = Landmark(
             name="goal",
@@ -38,7 +39,6 @@ class Scenario(BaseScenario):
             shape=Sphere(radius=0.3),
             color=Color.GREEN,
             mass=1,
-            linear_friction=0.1,
         )
         world.add_landmark(goal)
         return world

--- a/vmas/scenarios/velocity_control.py
+++ b/vmas/scenarios/velocity_control.py
@@ -15,25 +15,32 @@ class Scenario(BaseScenario):
         n_agents = kwargs.get("n_agents", 1)
 
         # Make world
-        world = World(batch_dim, device, drag=0.5)
+        world = World(batch_dim, device, drag=0, linear_friction=0)
         # Add agents
         for i in range(n_agents):
             # Constraint: all agents have same action range and multiplier
             agent = Agent(
-                name=f"agent {i}", collide=True, u_range=1, u_multiplier=1, f_range=None
+                name=f"agent {i}",
+                collide=True,
+                u_range=1,
+                u_multiplier=1,
+                mass=1,
+                f_range=None,
             )
             world.add_agent(agent)
-            agent.controller = VelocityController(agent, world.dt, [1.5, 0.15, 0.01], "standard")
+            agent.controller = VelocityController(
+                agent, world.dt, [1.5, 0.15, 0.01], "standard"
+            )
         goal = Landmark(
             name="goal",
             collide=True,
             movable=True,
             shape=Sphere(radius=0.3),
             color=Color.GREEN,
-            mass=0.5,
-            linear_friction = 0.01,
+            mass=1,
+            linear_friction=0.1,
         )
-        world.add_landmark(goal);
+        world.add_landmark(goal)
         return world
 
     def reset_world_at(self, env_index: int = None):
@@ -50,9 +57,9 @@ class Scenario(BaseScenario):
             )
         for landmark in self.world.landmarks:
             landmark.set_pos(
-                torch.tensor([0,1], device=self.world.device),
+                torch.tensor([0, 1], device=self.world.device),
                 batch_index=env_index,
-            )    
+            )
 
     def process_action(self, agent: Agent):
         # print( agent.state.vel );

--- a/vmas/simulator/utils.py
+++ b/vmas/simulator/utils.py
@@ -83,3 +83,9 @@ def clamp_with_norm(tensor: Tensor, max_norm: float):
 
 # clamp_scalar(x, low, high)
 clamp_scalar = lambda x, l, u: l if x < l else u if x > u else x;
+
+# clamp_tensor(x, limit)
+def clamp_tensor( t: Tensor, lim: float ):
+    t[t > lim] = lim;
+    t[t < -lim] = -lim;
+    return t;

--- a/vmas/simulator/utils.py
+++ b/vmas/simulator/utils.py
@@ -80,3 +80,6 @@ def clamp_with_norm(tensor: Tensor, max_norm: float):
     new_tensor = (tensor / norm.unsqueeze(-1)) * max_norm
     tensor[norm > max_norm] = new_tensor[norm > max_norm]
     return tensor
+
+# clamp_scalar(x, low, high)
+clamp_scalar = lambda x, l, u: l if x < l else u if x > u else x;

--- a/vmas/simulator/utils.py
+++ b/vmas/simulator/utils.py
@@ -80,12 +80,3 @@ def clamp_with_norm(tensor: Tensor, max_norm: float):
     new_tensor = (tensor / norm.unsqueeze(-1)) * max_norm
     tensor[norm > max_norm] = new_tensor[norm > max_norm]
     return tensor
-
-# clamp_scalar(x, low, high)
-clamp_scalar = lambda x, l, u: l if x < l else u if x > u else x;
-
-# clamp_tensor(x, limit)
-def clamp_tensor( t: Tensor, lim: float ):
-    t[t > lim] = lim;
-    t[t < -lim] = -lim;
-    return t;

--- a/vmas/simulator/velocity_controller.py
+++ b/vmas/simulator/velocity_controller.py
@@ -2,28 +2,75 @@
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 import torch
+import numpy as np;
 import vmas.simulator.core
 import vmas.simulator.utils
 
 
 class VelocityController:
-    def __init__(self, agent: vmas.simulator.core.Agent, dt: float):
+    def __init__(self, agent: vmas.simulator.core.Agent, dt: float, ctrl_params=[1, 0, 0], pid_form="standard"):
         self.agent = agent
         self.dt = dt
-        self.positions = []
-        self.velocities = []
+        # controller parameters: standard=[kP, intTs ,dervTs], parallel=[kP, kI, kD]
+        #    in parallel form, kI = kP/intTs and kD = kP*dervTs
+        self.ctrl_gain = ctrl_params[0];    # kP
+        if pid_form == "standard":
+            self.integralTs = ctrl_params[1];
+            self.derivativeTs = ctrl_params[2];
+        elif pid_form == "parallel":
+            if ctrl_params[1] == 0:
+                self.integralTs = 0.0;
+            else:
+                self.integralTs = self.ctrl_gain / ctrl_params[1];
+            self.derivativeTs = ctrl_params[2] / self.ctrl_gain;
+        else:
+            raise Exception( "PID form is either standard or parallel." );
+        
+        # in either form:
+        if self.integralTs == 0:
+            self.use_integrator = False;
+        else:
+            self.use_integrator = True;
+        
+        self.integrator_hist = 5;
+        self.integrator_windup_cutoff = 2;
+        # containers for integral & derivative control
+        self.vel_errs = []
+        self.prev_err = 0.0;
+
+        # do other initialisation bits
+        self.initialise();
+    
+    def initialise(self):
+        # initialise containter for integrator only if I-gain is not strictly zero
+        if self.use_integrator:
+            self.vel_errs = np.zeros(self.integrator_hist);
+
+    def reset(self):
+        self.vel_errs = np.zeros(self.integrator_hist);
+    
+    def integralError(self, err, _idx=[0]):
+        if not use_integrator:
+            return 0;
+        # update integrator container as a fast ring buffer
+        self.vel_errs[_idx[0]] = err;
+        _idx[0] = (_idx[0] + 1) % self.integrator_hist;
+        return (1.0/self.integralTs)*np.sum( self.vel_errs ) * self.dt;
+    
+    def rateError(self, err):
+        e = self.derivativeTs * (err - self.prev_err)/self.dt;
+        self.prev_err = err;
+        return e;
+            
 
     def process_force(self):
-        desired_velocity = self.agent.action.u
-        pos = self.agent.state.pos
-        vel = self.agent.state.vel
+        des_vel = self.agent.action.u;
+        cur_vel = self.agent.state.vel;
 
-        # Appending to the ques
-        self.positions.append(pos)
-        self.velocities.append(vel)
-
-        # Controller
-        force = ((desired_velocity - vel) / self.dt) * self.agent.mass
+        # apply control
+        err = des_vel - cur_vel;
+        u = ctrl_params[0] * ( err + self.integralError(err) + self.rateError(err) );
+        u = u * self.agent.mass;
 
         # Clamping force to limits
         if self.agent.max_f is not None:
@@ -31,9 +78,4 @@ class VelocityController:
         if self.agent.f_range is not None:
             force = torch.clamp(force, -self.agent.f_range, self.agent.f_range)
 
-        if len(self.positions) > 5:
-            self.positions.pop(0)
-        if len(self.velocities) > 5:
-            self.velocities.pop(0)
-
-        self.agent.action.u = force
+        self.agent.action.u = u;

--- a/vmas/simulator/velocity_controller.py
+++ b/vmas/simulator/velocity_controller.py
@@ -1,0 +1,39 @@
+#  Copyright (c) 2022.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+import torch
+import vmas.simulator.core
+import vmas.simulator.utils
+
+
+class VelocityController:
+    def __init__(self, agent: vmas.simulator.core.Agent, dt: float):
+        self.agent = agent
+        self.dt = dt
+        self.positions = []
+        self.velocities = []
+
+    def process_force(self):
+        desired_velocity = self.agent.action.u
+        pos = self.agent.state.pos
+        vel = self.agent.state.vel
+
+        # Appending to the ques
+        self.positions.append(pos)
+        self.velocities.append(vel)
+
+        # Controller
+        force = ((desired_velocity - vel) / self.dt) * self.agent.mass
+
+        # Clamping force to limits
+        if self.agent.max_f is not None:
+            force = vmas.simulator.utils.clamp_with_norm(force, self.agent.max_f)
+        if self.agent.f_range is not None:
+            force = torch.clamp(force, -self.agent.f_range, self.agent.f_range)
+
+        if len(self.positions) > 5:
+            self.positions.pop(0)
+        if len(self.velocities) > 5:
+            self.velocities.pop(0)
+
+        self.agent.action.u = force

--- a/vmas/simulator/velocity_controller.py
+++ b/vmas/simulator/velocity_controller.py
@@ -2,93 +2,99 @@
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 import torch
-import numpy as np;
 import vmas.simulator.core
 import vmas.simulator.utils
 
-"""
-Implements PID controller for velocity targets found in agent.action.u.
-Two forms of the PID controller are implemented: standard, and parallel. The controller takes 3 params, which
-are interpreted differently based on the form.
-> Standard form: ctrl_params=[gain, intg_ts, derv_ts]
-                    intg_ts: rise time for integrator (err will be tolerated for this interval)
-                    derv_ts: seek time for derivative (err is predicted over this interval)
-                    These are specified in 1/dt scale (0.5 means 0.5/0.1==5sec)
-> Parallel form: ctrl_params=[kP, kI, kD]
-                    kI and kD have no simple physical meaning, but are related to standard form params.
-                    intg_ts = kP/kI and kD/kP = derv_ts
-"""
+
 class VelocityController:
-    def __init__(self, agent: vmas.simulator.core.Agent, dt: float, ctrl_params=[1, 0, 0], pid_form="standard"):
+    """
+    Implements PID controller for velocity targets found in agent.action.u.
+    Two forms of the PID controller are implemented: standard, and parallel. The controller takes 3 params, which
+    are interpreted differently based on the form.
+    > Standard form: ctrl_params=[gain, intg_ts, derv_ts]
+                        intg_ts: rise time for integrator (err will be tolerated for this interval)
+                        derv_ts: seek time for derivative (err is predicted over this interval)
+                        These are specified in 1/dt scale (0.5 means 0.5/0.1==5sec)
+    > Parallel form: ctrl_params=[kP, kI, kD]
+                        kI and kD have no simple physical meaning, but are related to standard form params.
+                        intg_ts = kP/kI and kD/kP = derv_ts
+    """
+
+    def __init__(
+        self,
+        agent: vmas.simulator.core.Agent,
+        dt: float,
+        ctrl_params=[1, 0, 0],
+        pid_form="standard",
+    ):
         self.agent = agent
         self.dt = dt
         # controller parameters: standard=[kP, intgTs ,dervTs], parallel=[kP, kI, kD]
         #    in parallel form, kI = kP/intgTs and kD = kP*dervTs
-        self.ctrl_gain = ctrl_params[0];    # kP
+        self.ctrl_gain = ctrl_params[0]
+        # kP
         if pid_form == "standard":
-            self.integralTs = ctrl_params[1];
-            self.derivativeTs = ctrl_params[2];
+            self.integralTs = ctrl_params[1]
+            self.derivativeTs = ctrl_params[2]
         elif pid_form == "parallel":
             if ctrl_params[1] == 0:
-                self.integralTs = 0.0;
+                self.integralTs = 0.0
             else:
-                self.integralTs = self.ctrl_gain / ctrl_params[1];
-            self.derivativeTs = ctrl_params[2] / self.ctrl_gain;
+                self.integralTs = self.ctrl_gain / ctrl_params[1]
+            self.derivativeTs = ctrl_params[2] / self.ctrl_gain
         else:
-            raise Exception( "PID form is either standard or parallel." );
-        
+            raise Exception("PID form is either standard or parallel.")
+
         # in either form:
         if self.integralTs == 0:
-            self.use_integrator = False;
+            self.use_integrator = False
         else:
-            self.use_integrator = True;
+            self.use_integrator = True
             # set windup limit to 50% of agent's max force
-            fmax = self.agent.max_f if self.agent.max_f is not None else 2.0;
-            self.integrator_windup_cutoff = 0.5 * fmax * self.integralTs/(self.dt * self.ctrl_gain);
-        
-        # containers for integral & derivative control
-        self.accum_errs = 0.0;
-        self.prev_err = 0.0;
+            fmax = self.agent.max_f if self.agent.max_f is not None else 2.0
+            self.integrator_windup_cutoff = (
+                0.5 * fmax * self.integralTs / (self.dt * self.ctrl_gain)
+            )
 
-        # do other initialisation bits
-        self.reset();
+        # containers for integral & derivative control
+        self.accum_errs = 0.0
+        self.prev_err = 0.0
+
+        # do other initialization bits
+        self.reset()
 
     def reset(self):
-        self.accum_errs = 0.0;
-        self.prev_err = 0.0;
-    
+        self.accum_errs = 0.0
+        self.prev_err = 0.0
+
     def integralError(self, err):
         if not self.use_integrator:
-            return 0;
+            return 0
         # fixed-length history (not recommended):
-        ### if len( self.accum_errs ) > self.integrator_hist-1:
-        ###    self.accum_errs.pop(0);
-        ### self.accum_errs.append( err );
-        ### return (1.0/self.integralTs) * torch.stack( self.accum_errs, dim=1 ).sum(dim=1) * self.dt;
-        
-        self.accum_errs += ( self.dt * err );
-        self.accum_errs = vmas.simulator.utils.clamp_tensor(self.accum_errs, self.integrator_windup_cutoff);
-        return (1.0/self.integralTs) * self.accum_errs;
-    
+        # if len( self.accum_errs ) > self.integrator_hist-1:
+        #    self.accum_errs.pop(0);
+        # self.accum_errs.append( err );
+        # return (1.0/self.integralTs) * torch.stack( self.accum_errs, dim=1 ).sum(dim=1) * self.dt;
+
+        self.accum_errs += self.dt * err
+        self.accum_errs = self.accum_errs.clamp(
+            -self.integrator_windup_cutoff, self.integrator_windup_cutoff
+        )
+
+        return (1.0 / self.integralTs) * self.accum_errs
+
     def rateError(self, err):
-        e = self.derivativeTs * (err - self.prev_err)/self.dt;
-        self.prev_err = err;
-        return e;
-            
+        e = self.derivativeTs * (err - self.prev_err) / self.dt
+        self.prev_err = err
+        return e
 
     def process_force(self):
-        des_vel = self.agent.action.u;
-        cur_vel = self.agent.state.vel;
+        des_vel = self.agent.action.u
+        cur_vel = self.agent.state.vel
 
         # apply control
-        err = des_vel - cur_vel;
-        u = self.ctrl_gain * ( err + self.integralError(err) + self.rateError(err) );
-        u = u * self.agent.mass;
+        err = des_vel - cur_vel
+        u = self.ctrl_gain * (err + self.integralError(err) + self.rateError(err))
+        u = u * self.agent.mass
 
-        # Clamping force to limits
-        if self.agent.max_f is not None:
-            u = vmas.simulator.utils.clamp_with_norm(u, self.agent.max_f)
-        if self.agent.f_range is not None:
-            u = torch.clamp(u, -self.agent.f_range, self.agent.f_range)
-
-        self.agent.action.u = u;
+        self.agent.action.u = u

--- a/vmas/simulator/velocity_controller.py
+++ b/vmas/simulator/velocity_controller.py
@@ -45,7 +45,6 @@ class VelocityController:
             # set windup limit to 50% of agent's max force
             fmax = self.agent.max_f if self.agent.max_f is not None else 2.0;
             self.integrator_windup_cutoff = 0.5 * fmax * self.integralTs/(self.dt * self.ctrl_gain);
-            print( "Intg cutoff: ", self.integrator_windup_cutoff );
         
         # containers for integral & derivative control
         self.accum_errs = 0.0;
@@ -68,9 +67,7 @@ class VelocityController:
         ### return (1.0/self.integralTs) * torch.stack( self.accum_errs, dim=1 ).sum(dim=1) * self.dt;
         
         self.accum_errs += ( self.dt * err );
-        #self.accum_errs = vmas.simulator.utils.clamp_tensor(self.accum_errs,\
-        #                                                 -self.integrator_windup_cutoff,\
-        #                                                 self.integrator_windup_cutoff);
+        self.accum_errs = vmas.simulator.utils.clamp_tensor(self.accum_errs, self.integrator_windup_cutoff);
         return (1.0/self.integralTs) * self.accum_errs;
     
     def rateError(self, err):
@@ -95,5 +92,3 @@ class VelocityController:
             u = torch.clamp(u, -self.agent.f_range, self.agent.f_range)
 
         self.agent.action.u = u;
-        # before_after = des_vel[0].tolist() + u[0].tolist() + cur_vel[0].tolist();
-        # print( *before_after );

--- a/vmas/simulator/velocity_controller.py
+++ b/vmas/simulator/velocity_controller.py
@@ -6,13 +6,24 @@ import numpy as np;
 import vmas.simulator.core
 import vmas.simulator.utils
 
-
+"""
+Implements PID controller for velocity targets found in agent.action.u.
+Two forms of the PID controller are implemented: standard, and parallel. The controller takes 3 params, which
+are interpreted differently based on the form.
+> Standard form: ctrl_params=[gain, intg_ts, derv_ts]
+                    intg_ts: rise time for integrator (err will be tolerated for this interval)
+                    derv_ts: seek time for derivative (err is predicted over this interval)
+                    These are specified in 1/dt scale (0.5 means 0.5/0.1==5sec)
+> Parallel form: ctrl_params=[kP, kI, kD]
+                    kI and kD have no simple physical meaning, but are related to standard form params.
+                    intg_ts = kP/kI and kD/kP = derv_ts
+"""
 class VelocityController:
     def __init__(self, agent: vmas.simulator.core.Agent, dt: float, ctrl_params=[1, 0, 0], pid_form="standard"):
         self.agent = agent
         self.dt = dt
-        # controller parameters: standard=[kP, intTs ,dervTs], parallel=[kP, kI, kD]
-        #    in parallel form, kI = kP/intTs and kD = kP*dervTs
+        # controller parameters: standard=[kP, intgTs ,dervTs], parallel=[kP, kI, kD]
+        #    in parallel form, kI = kP/intgTs and kD = kP*dervTs
         self.ctrl_gain = ctrl_params[0];    # kP
         if pid_form == "standard":
             self.integralTs = ctrl_params[1];
@@ -31,36 +42,36 @@ class VelocityController:
             self.use_integrator = False;
         else:
             self.use_integrator = True;
+            # set windup limit to 50% of agent's max force
+            fmax = self.agent.max_f if self.agent.max_f is not None else 2.0;
+            self.integrator_windup_cutoff = 0.5 * fmax * self.integralTs/(self.dt * self.ctrl_gain);
+            print( "Intg cutoff: ", self.integrator_windup_cutoff );
         
-        self.integrator_hist = 200;
-        self.integrator_windup_cutoff = 2;
         # containers for integral & derivative control
-        self.vel_errs = []
+        self.accum_errs = 0.0;
         self.prev_err = 0.0;
 
         # do other initialisation bits
-        self.initialise();
-    
-    def initialise(self):
-        # initialise containter for integrator only if I-gain is not strictly zero
-        #if self.use_integrator:
-        #    self.vel_errs = np.zeros(self.integrator_hist);
-        self.vel_errs = [];
+        self.reset();
 
     def reset(self):
-        self.vel_errs = np.zeros(self.integrator_hist);
+        self.accum_errs = 0.0;
+        self.prev_err = 0.0;
     
-    def integralError(self, err, _idx=[0]):
+    def integralError(self, err):
         if not self.use_integrator:
             return 0;
-        # update integrator container as a fast ring buffer
-        ### self.vel_errs[_idx[0]] = err;
-        ### _idx[0] = (_idx[0] + 1) % self.integrator_hist;
-        ### return (1.0/self.integralTs)*np.sum( self.vel_errs ) * self.dt;
-        if len( self.vel_errs ) > self.integrator_hist-1:
-            self.vel_errs.pop(0);
-        self.vel_errs.append( err );
-        return (1.0/self.integralTs) * torch.stack( self.vel_errs, dim=1 ).sum(dim=1) * self.dt;
+        # fixed-length history (not recommended):
+        ### if len( self.accum_errs ) > self.integrator_hist-1:
+        ###    self.accum_errs.pop(0);
+        ### self.accum_errs.append( err );
+        ### return (1.0/self.integralTs) * torch.stack( self.accum_errs, dim=1 ).sum(dim=1) * self.dt;
+        
+        self.accum_errs += ( self.dt * err );
+        #self.accum_errs = vmas.simulator.utils.clamp_tensor(self.accum_errs,\
+        #                                                 -self.integrator_windup_cutoff,\
+        #                                                 self.integrator_windup_cutoff);
+        return (1.0/self.integralTs) * self.accum_errs;
     
     def rateError(self, err):
         e = self.derivativeTs * (err - self.prev_err)/self.dt;
@@ -79,10 +90,10 @@ class VelocityController:
 
         # Clamping force to limits
         if self.agent.max_f is not None:
-            force = vmas.simulator.utils.clamp_with_norm(force, self.agent.max_f)
+            u = vmas.simulator.utils.clamp_with_norm(u, self.agent.max_f)
         if self.agent.f_range is not None:
-            force = torch.clamp(force, -self.agent.f_range, self.agent.f_range)
+            u = torch.clamp(u, -self.agent.f_range, self.agent.f_range)
 
         self.agent.action.u = u;
-        before_after = des_vel[0].tolist() + u[0].tolist() + cur_vel[0].tolist();
-        print( *before_after );
+        # before_after = des_vel[0].tolist() + u[0].tolist() + cur_vel[0].tolist();
+        # print( *before_after );

--- a/vmas/simulator/velocity_controller.py
+++ b/vmas/simulator/velocity_controller.py
@@ -3,7 +3,7 @@
 #  All rights reserved.
 import math
 import warnings
-import torch
+
 import vmas.simulator.core
 import vmas.simulator.utils
 
@@ -33,7 +33,7 @@ class VelocityController:
         self.dt = dt
         # controller parameters: standard=[kP, intgTs ,dervTs], parallel=[kP, kI, kD]
         #    in parallel form, kI = kP/intgTs and kD = kP*dervTs
-        self.ctrl_gain = ctrl_params[0]         # kP
+        self.ctrl_gain = ctrl_params[0]  # kP
         if pid_form == "standard":
             self.integralTs = ctrl_params[1]
             self.derivativeTs = ctrl_params[2]
@@ -52,17 +52,18 @@ class VelocityController:
         else:
             self.use_integrator = True
             # set windup limit to 50% of agent's max force
-            fmax = min( self.agent.max_f,
-                        self.agent.f_range, 
-                        key=lambda x: x if x is not None else math.inf
+            fmax = min(
+                self.agent.max_f,
+                self.agent.f_range,
+                key=lambda x: x if x is not None else math.inf,
             )
             if fmax is not None:
                 self.integrator_windup_cutoff = (
                     0.5 * fmax * self.integralTs / (self.dt * self.ctrl_gain)
                 )
             else:
-                self.integrator_windup_cutoff = None;
-                warnings.warn( "Force limits not specified. Integrator can wind up!" );
+                self.integrator_windup_cutoff = None
+                warnings.warn("Force limits not specified. Integrator can wind up!")
 
         # containers for integral & derivative control
         self.accum_errs = 0.0


### PR DESCRIPTION
This reinterprets `agent.action.u` as a desired velocity (as opposed to force, currently) and produces a force necessary to maintain that velocity. The implementation is currently a full PID control over velocity with support for both 'standard' and 'parallel' forms.

This should help create implementations that are more suited for holonomic robots that can regulate their inertial velocities but not forces.