### PR TITLE
[Feature] Text can be specified from custom scenario via extra_render.

### DIFF
--- a/vmas/scenarios/debug/diff_drive.py
+++ b/vmas/scenarios/debug/diff_drive.py
@@ -75,8 +75,8 @@ class Scenario(BaseScenario):
 
     def observation(self, agent: Agent):
         observations = [
-            agent.state.pos,
-            agent.state.vel,
+            agent.state.pos, agent.state.rot,
+            agent.state.vel, agent.state.ang_vel, t
         ]
         return torch.cat(
             observations,
@@ -102,6 +102,11 @@ class Scenario(BaseScenario):
             line.add_attr(xform)
             line.set_color(*color)
             geoms.append(line)
+
+        # DO NOT COMMIT THIS INTO MASTER, IT IS ONLY TO SHOW TEXT RENDER EXAMPLE
+        self.render_text = []  # Reset the text from last round
+        for i in range(2):
+            self.render_text.append(f"{i}: This is a test of custom text rendering from scenario file")
 
         return geoms
 

--- a/vmas/simulator/scenario.py
+++ b/vmas/simulator/scenario.py
@@ -27,6 +27,8 @@ class BaseScenario(ABC):
         self.plot_grid = False
         # The distance between lines in the background grid
         self.grid_spacing = 0.1
+        # Text to be rendered by environment:
+        self.render_text = []
 
     @property
     def world(self):


### PR DESCRIPTION
I needed a feature for visualising custom text like in the interative_rendere but I wanted to do it from the my scenario.
It was not possible to create TextLine from the scenario as it needed the viewer which is only available from the envirionment.
So the choice was to either give the extra_render method access to the viewer (which opens up for lots of functionality, but also for missuse) or to have this variable render_text which the environment checks for.

You can take this, modify or just leave it as it was just a functionality i needed.