### PR TITLE
 [Feature] Text can be specified from custom scenario via extra_render. 

### DIFF
--- a/vmas/interactive_rendering.py
+++ b/vmas/interactive_rendering.py
@@ -37,12 +37,12 @@ class InteractiveEnv:
     """
 
     def __init__(
-        self,
-        env: GymWrapper,
-        control_two_agents: bool = False,
-        display_info: bool = True,
-        save_render: bool = False,
-        render_name: str = "interactive",
+            self,
+            env: GymWrapper,
+            control_two_agents: bool = False,
+            display_info: bool = True,
+            save_render: bool = False,
+            render_name: str = "interactive",
     ):
         self.env = env
         self.control_two_agents = control_two_agents
@@ -68,7 +68,7 @@ class InteractiveEnv:
 
         if self.control_two_agents:
             assert (
-                self.n_agents >= 2
+                    self.n_agents >= 2
             ), "Control_two_agents is true but not enough agents in scenario"
 
         self.env.render()
@@ -103,17 +103,17 @@ class InteractiveEnv:
                 for agent in self.agents
             ]
             action_list[self.current_agent_index] = self.u[
-                : self.env.unwrapped().get_agent_action_size(
-                    self.agents[self.current_agent_index]
-                )
-            ]
+                                                    : self.env.unwrapped().get_agent_action_size(
+                                                        self.agents[self.current_agent_index]
+                                                    )
+                                                    ]
 
             if self.n_agents > 1 and self.control_two_agents:
                 action_list[self.current_agent_index2] = self.u2[
-                    : self.env.unwrapped().get_agent_action_size(
-                        self.agents[self.current_agent_index2]
-                    )
-                ]
+                                                         : self.env.unwrapped().get_agent_action_size(
+                                                             self.agents[self.current_agent_index2]
+                                                         )
+                                                         ]
             obs, rew, done, info = self.env.step(action_list)
 
             if self.display_info:
@@ -124,7 +124,7 @@ class InteractiveEnv:
                 message = f"Obs: {obs_str[:len(obs_str) // 2]}"
                 self._write_values(self.text_idx + 1, message)
 
-                message = f"Rew: {round(rew[self.current_agent_index],3)}"
+                message = f"Rew: {round(rew[self.current_agent_index], 3)}"
                 self._write_values(self.text_idx + 2, message)
 
                 total_rew = list(map(add, total_rew, rew))
@@ -149,22 +149,25 @@ class InteractiveEnv:
 
     def _init_text(self):
         from vmas.simulator import rendering
-
-        try:
-            self.text_idx = len(self.env.unwrapped().viewer.text_lines)
-        except AttributeError:
-            self.text_idx = 0
+        state = rendering.RenderStateSingleton()
+        self.text_idx = len(state.text_lines)
 
         for i in range(N_TEXT_LINES_INTERACTIVE):
             text_line = rendering.TextLine(
-                self.env.unwrapped().viewer.window, self.text_idx + i
+                # self.env.unwrapped().viewer.window,
+                self.text_idx + i
             )
-            self.env.unwrapped().viewer.text_lines.append(text_line)
+            state.text_lines.append(text_line)
 
     def _write_values(self, index: int, message: str, font_size: int = 15):
-        self.env.unwrapped().viewer.text_lines[index].set_text(
+        from vmas.simulator import rendering
+        rendering.RenderStateSingleton().text_lines[index].set_text(
             message, font_size=font_size
         )
+
+        # self.env.unwrapped().viewer.text_lines[index].set_text(
+        #     message, font_size=font_size
+        # )
 
     # keyboard event callbacks
     def _key_press(self, k, mod):
@@ -300,11 +303,11 @@ class InteractiveEnv:
 
 
 def render_interactively(
-    scenario: Union[str, BaseScenario],
-    control_two_agents: bool = False,
-    display_info: bool = True,
-    save_render: bool = False,
-    **kwargs,
+        scenario: Union[str, BaseScenario],
+        control_two_agents: bool = False,
+        display_info: bool = True,
+        save_render: bool = False,
+        **kwargs,
 ):
     """
     Use this script to interactively play with scenarios

--- a/vmas/scenarios/debug/diff_drive.py
+++ b/vmas/scenarios/debug/diff_drive.py
@@ -75,8 +75,8 @@ class Scenario(BaseScenario):
 
     def observation(self, agent: Agent):
         observations = [
-            agent.state.pos,
-            agent.state.vel,
+            agent.state.pos, agent.state.rot,
+            agent.state.vel, agent.state.ang_vel, t
         ]
         return torch.cat(
             observations,
@@ -102,6 +102,11 @@ class Scenario(BaseScenario):
             line.add_attr(xform)
             line.set_color(*color)
             geoms.append(line)
+
+        # DO NOT COMMIT THIS INTO MASTER, IT IS ONLY TO SHOW TEXT RENDER EXAMPLE
+        self.render_text = []  # Reset the text from last round
+        for i in range(2):
+            self.render_text.append(f"{i}: This is a test of custom text rendering from scenario file")
 
         return geoms
 

--- a/vmas/simulator/environment/environment.py
+++ b/vmas/simulator/environment/environment.py
@@ -8,6 +8,7 @@ from typing import List, Tuple, Callable, Optional, Union, Dict
 
 import numpy as np
 import torch
+import typing
 from gym import spaces
 from torch import Tensor
 from vmas.simulator.core import Agent, TorchVectorizedObject
@@ -22,6 +23,9 @@ from vmas.simulator.utils import (
     DEVICE_TYPING,
     override,
 )
+
+if typing.TYPE_CHECKING:
+    from vmas.simulator.rendering import Viewer
 
 
 # environment for all agents in the multiagent world
@@ -63,7 +67,7 @@ class Environment(TorchVectorizedObject):
         # rendering
         self.render_geoms_xform = None
         self.render_geoms = None
-        self.viewer = None
+        self.viewer: Viewer = None
         self.headless = None
         self.visible_display = None
 
@@ -636,11 +640,6 @@ class Environment(TorchVectorizedObject):
 
         self.viewer.add_onetime_list(self.scenario.extra_render(env_index))
 
-        # Rendering the text set from extra_render method:
-        for message in self.scenario.render_text:
-            self.viewer.text_lines[text_idx].set_text(message)
-            text_idx += 1
-
         for entity in self.world.entities:
             self.viewer.add_onetime_list(entity.render(env_index=env_index))
 
@@ -679,16 +678,9 @@ class Environment(TorchVectorizedObject):
         if self.world.dim_c > 0:
             for agent in self.world.agents:
                 if not agent.silent:
-                    text_line = rendering.TextLine(self.viewer.window, idx)
+                    text_line = rendering.TextLine(idx)
                     self.viewer.text_lines.append(text_line)
                     idx += 1
-
-        # Overhead in drawing (called once), but we get the number of lines expected to be rendered:
-        self.scenario.extra_render(env_index)
-        for _ in self.scenario.render_text:
-            text_line = rendering.TextLine(self.viewer.window, idx)
-            self.viewer.text_lines.append(text_line)
-            idx += 1
 
     @override(TorchVectorizedObject)
     def to(self, device: DEVICE_TYPING):

--- a/vmas/simulator/scenario.py
+++ b/vmas/simulator/scenario.py
@@ -27,6 +27,8 @@ class BaseScenario(ABC):
         self.plot_grid = False
         # The distance between lines in the background grid
         self.grid_spacing = 0.1
+        # Text to be rendered by environment:
+        self.render_text = []
 
     @property
     def world(self):

--- a/vmas/simulator/scenario.py
+++ b/vmas/simulator/scenario.py
@@ -33,8 +33,6 @@ class BaseScenario(ABC):
         self.plot_grid = False
         # The distance between lines in the background grid
         self.grid_spacing = 0.1
-        # Text to be rendered by environment:
-        self.render_text = []
 
     @property
     def world(self):


### PR DESCRIPTION
I did a mistake and deleted the branch.... here it is again

I needed a feature for visualising custom text like in the interative_rendere but I wanted to do it from the my scenario.
It was not possible to create TextLine from the scenario as it needed the viewer which is only available from the envirionment.
So the choice was to either give the extra_render method access to the viewer (which opens up for lots of functionality, but also for missuse) or to have this variable render_text which the environment checks for.

You can take this, modify or just leave it as it was just a functionality i needed.
