### PR TITLE
[Feature] Actions detached from physics and allow any number of actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,8 +405,9 @@ To create a fake screen you need to have `Xvfb` installed.
 - [ ] Reset any number of dimensions
 - [ ] Improve test efficiency and add new tests
 - [ ] Implement 1D camera sensor
-- [ ] Allow any number of actions
 - [ ] Implement 2D birds eye view camera sensor
+- [ ] Implement 2D drone dynamics
+- [X] Allow any number of actions
 - [X] Improve VMAS performance
 - [X] Dict obs support in torchrl
 - [X] Make TextLine a Geom usable in a scenario

--- a/vmas/make_env.py
+++ b/vmas/make_env.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 
@@ -22,6 +22,7 @@ def make_env(
     max_steps: Optional[int] = None,
     seed: Optional[int] = None,
     dict_spaces: bool = False,
+    multidiscrete: bool = False,
     **kwargs,
 ):
     """
@@ -35,7 +36,10 @@ def make_env(
         max_steps: Maximum number of steps in each vectorized environment after which done is returned
         seed: seed
         dict_spaces:  Weather to use dictionary i/o spaces with format {agent_name: tensor}
-        for obs, rewards, and info instead of tuples.
+            for obs, rewards, and info instead of tuples.
+        multidiscrete (bool): Whether to use multidiscrete action spaces when continuous_actions=False.
+            Otherwise, (default) the action space will be Discrete, and it will be the cartesian product of the
+            action spaces of an agent.
         **kwargs ():
 
     Returns:
@@ -55,6 +59,7 @@ def make_env(
         max_steps=max_steps,
         seed=seed,
         dict_spaces=dict_spaces,
+        multidiscrete=multidiscrete,
         **kwargs,
     )
 

--- a/vmas/make_env.py
+++ b/vmas/make_env.py
@@ -22,7 +22,7 @@ def make_env(
     max_steps: Optional[int] = None,
     seed: Optional[int] = None,
     dict_spaces: bool = False,
-    multidiscrete: bool = False,
+    multidiscrete_actions: bool = False,
     **kwargs,
 ):
     """
@@ -37,7 +37,7 @@ def make_env(
         seed: seed
         dict_spaces:  Weather to use dictionary i/o spaces with format {agent_name: tensor}
             for obs, rewards, and info instead of tuples.
-        multidiscrete (bool): Whether to use multidiscrete action spaces when continuous_actions=False.
+        multidiscrete_actions (bool): Whether to use multidiscrete_actions action spaces when continuous_actions=False.
             Otherwise, (default) the action space will be Discrete, and it will be the cartesian product of the
             action spaces of an agent.
         **kwargs ():
@@ -59,7 +59,7 @@ def make_env(
         max_steps=max_steps,
         seed=seed,
         dict_spaces=dict_spaces,
-        multidiscrete=multidiscrete,
+        multidiscrete_actions=multidiscrete_actions,
         **kwargs,
     )
 

--- a/vmas/scenarios/debug/diff_drive.py
+++ b/vmas/scenarios/debug/diff_drive.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 import typing
@@ -9,6 +9,7 @@ import torch
 from vmas import render_interactively
 from vmas.simulator.core import Agent, World
 from vmas.simulator.dynamics.diff_drive import DiffDriveDynamics
+from vmas.simulator.dynamics.holonomic_with_rot import HolonomicWithRotationDynamics
 from vmas.simulator.scenario import BaseScenario
 from vmas.simulator.utils import Color, ScenarioUtils
 
@@ -39,16 +40,24 @@ class Scenario(BaseScenario):
         world = World(batch_dim, device, substeps=10)
 
         for i in range(self.n_agents):
-            agent = Agent(
-                name=f"agent_{i}",
-                collide=True,
-                render_action=True,
-                u_range=1,
-                u_rot_range=1,
-                u_rot_multiplier=0.001,
-            )
             if i == 0:
-                agent.dynamics = DiffDriveDynamics(agent, world, integration="rk4")
+                agent = Agent(
+                    name=f"diff_drive_{i}",
+                    collide=True,
+                    render_action=True,
+                    u_range=[1, 1],
+                    u_multiplier=[1, 0.001],
+                    dynamics=DiffDriveDynamics(world, integration="rk4"),
+                )
+            else:
+                agent = Agent(
+                    name=f"holo_rot_{i}",
+                    collide=True,
+                    render_action=True,
+                    u_range=[1, 1, 1],
+                    u_multiplier=[1, 1, 0.001],
+                    dynamics=HolonomicWithRotationDynamics(),
+                )
 
             world.add_agent(agent)
 
@@ -63,12 +72,6 @@ class Scenario(BaseScenario):
             x_bounds=(-1, 1),
             y_bounds=(-1, 1),
         )
-
-    def process_action(self, agent: Agent):
-        try:
-            agent.dynamics.process_force()
-        except AttributeError:
-            pass
 
     def reward(self, agent: Agent):
         return torch.zeros(self.world.batch_dim)

--- a/vmas/scenarios/debug/diff_drive.py
+++ b/vmas/scenarios/debug/diff_drive.py
@@ -8,8 +8,8 @@ import torch
 
 from vmas import render_interactively
 from vmas.simulator.core import Agent, World
-from vmas.simulator.dynamics.diff_drive import DiffDriveDynamics
-from vmas.simulator.dynamics.holonomic_with_rot import HolonomicWithRotationDynamics
+from vmas.simulator.dynamics.diff_drive import DiffDrive
+from vmas.simulator.dynamics.holonomic_with_rot import HolonomicWithRotation
 from vmas.simulator.scenario import BaseScenario
 from vmas.simulator.utils import Color, ScenarioUtils
 
@@ -47,7 +47,7 @@ class Scenario(BaseScenario):
                     render_action=True,
                     u_range=[1, 1],
                     u_multiplier=[1, 0.001],
-                    dynamics=DiffDriveDynamics(world, integration="rk4"),
+                    dynamics=DiffDrive(world, integration="rk4"),
                 )
             else:
                 agent = Agent(
@@ -56,7 +56,7 @@ class Scenario(BaseScenario):
                     render_action=True,
                     u_range=[1, 1, 1],
                     u_multiplier=[1, 1, 0.001],
-                    dynamics=HolonomicWithRotationDynamics(),
+                    dynamics=HolonomicWithRotation(),
                 )
 
             world.add_agent(agent)

--- a/vmas/scenarios/debug/kinematic_bicycle.py
+++ b/vmas/scenarios/debug/kinematic_bicycle.py
@@ -82,13 +82,6 @@ class Scenario(BaseScenario):
             y_bounds=(-1, 1),
         )
 
-    def process_action(self, agent: Agent):
-        if hasattr(agent, "dynamics") and hasattr(agent.dynamics, "process_force"):
-            agent.dynamics.process_force()
-        else:
-            # The agent does not have a dynamics property, or it does not have a process_force method
-            pass
-
     def reward(self, agent: Agent):
         return torch.zeros(self.world.batch_dim)
 

--- a/vmas/scenarios/debug/kinematic_bicycle.py
+++ b/vmas/scenarios/debug/kinematic_bicycle.py
@@ -1,3 +1,7 @@
+#  Copyright (c) 2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+
 import typing
 from typing import List
 
@@ -5,6 +9,7 @@ import torch
 
 from vmas import render_interactively
 from vmas.simulator.core import Agent, World, Box
+from vmas.simulator.dynamics.holonomic_with_rot import HolonomicWithRotationDynamics
 from vmas.simulator.dynamics.kinematic_bicycle import KinematicBicycleDynamics
 from vmas.simulator.scenario import BaseScenario
 from vmas.simulator.utils import Color, ScenarioUtils
@@ -12,44 +17,55 @@ from vmas.simulator.utils import Color, ScenarioUtils
 if typing.TYPE_CHECKING:
     from vmas.simulator.rendering import Geom
 
+
 class Scenario(BaseScenario):
     def make_world(self, batch_dim: int, device: torch.device, **kwargs):
         """
         Kinematic bicycle model example scenario
         """
         self.n_agents = kwargs.get("n_agents", 2)
-        width = kwargs.get("width", 0.1) # Agent width
-        l_f = kwargs.get("l_f", 0.1) # Distance between the front axle and the center of gravity
-        l_r = kwargs.get("l_r", 0.1) # Distance between the rear axle and the center of gravity
-        max_steering_angle = kwargs.get("max_steering_angle", torch.deg2rad(torch.tensor(30.0)))
+        width = kwargs.get("width", 0.1)  # Agent width
+        l_f = kwargs.get(
+            "l_f", 0.1
+        )  # Distance between the front axle and the center of gravity
+        l_r = kwargs.get(
+            "l_r", 0.1
+        )  # Distance between the rear axle and the center of gravity
+        max_steering_angle = kwargs.get(
+            "max_steering_angle", torch.deg2rad(torch.tensor(30.0))
+        )
 
         # Make world
-        world = World(batch_dim, device, substeps=10)
+        world = World(batch_dim, device, substeps=10, collision_force=500)
 
         for i in range(self.n_agents):
             if i == 0:
                 # Use the kinematic bicycle model for the first agent
                 agent = Agent(
-                    name=f"agent_{i}",
-                    shape=Box(length=l_f+l_r, width=width),
-                    collide=False, # turn off since the check of box-box collisions is quite expensive currently
+                    name=f"bicycle_{i}",
+                    shape=Box(length=l_f + l_r, width=width),
+                    collide=True,
                     render_action=True,
-                    u_range=1,
-                    u_rot_range=max_steering_angle,
-                    u_rot_multiplier=1,
-                )
-                agent.dynamics = KinematicBicycleDynamics(
-                    agent, world, width=width, l_f=l_f, l_r=l_r, max_steering_angle=max_steering_angle, integration="euler" # one of "euler", "rk4"
+                    u_range=[1, max_steering_angle],
+                    u_multiplier=[1, 1],
+                    dynamics=KinematicBicycleDynamics(
+                        world,
+                        width=width,
+                        l_f=l_f,
+                        l_r=l_r,
+                        max_steering_angle=max_steering_angle,
+                        integration="euler",  # one of "euler", "rk4"
+                    ),
                 )
             else:
                 agent = Agent(
-                    name=f"agent_{i}",
-                    shape=Box(length=l_f+l_r, width=width),
-                    collide=False,
+                    name=f"holo_rot_{i}",
+                    shape=Box(length=l_f + l_r, width=width),
+                    collide=True,
                     render_action=True,
-                    u_range=1,
-                    u_rot_range=1,
-                    u_rot_multiplier=0.001,
+                    u_range=[1, 1, 1],
+                    u_multiplier=[1, 1, 0.001],
+                    dynamics=HolonomicWithRotationDynamics(),
                 )
 
             world.add_agent(agent)
@@ -67,7 +83,7 @@ class Scenario(BaseScenario):
         )
 
     def process_action(self, agent: Agent):
-        if hasattr(agent, 'dynamics') and hasattr(agent.dynamics, 'process_force'):
+        if hasattr(agent, "dynamics") and hasattr(agent.dynamics, "process_force"):
             agent.dynamics.process_force()
         else:
             # The agent does not have a dynamics property, or it does not have a process_force method
@@ -108,6 +124,14 @@ class Scenario(BaseScenario):
 
         return geoms
 
+
 # ... and the code to run the simulation.
 if __name__ == "__main__":
-    render_interactively(__file__, control_two_agents=True, width=0.1, l_f=0.1, l_r=0.1, display_info=True)
+    render_interactively(
+        __file__,
+        control_two_agents=True,
+        width=0.1,
+        l_f=0.1,
+        l_r=0.1,
+        display_info=True,
+    )

--- a/vmas/scenarios/debug/kinematic_bicycle.py
+++ b/vmas/scenarios/debug/kinematic_bicycle.py
@@ -9,8 +9,8 @@ import torch
 
 from vmas import render_interactively
 from vmas.simulator.core import Agent, World, Box
-from vmas.simulator.dynamics.holonomic_with_rot import HolonomicWithRotationDynamics
-from vmas.simulator.dynamics.kinematic_bicycle import KinematicBicycleDynamics
+from vmas.simulator.dynamics.holonomic_with_rot import HolonomicWithRotation
+from vmas.simulator.dynamics.kinematic_bicycle import KinematicBicycle
 from vmas.simulator.scenario import BaseScenario
 from vmas.simulator.utils import Color, ScenarioUtils
 
@@ -48,7 +48,7 @@ class Scenario(BaseScenario):
                     render_action=True,
                     u_range=[1, max_steering_angle],
                     u_multiplier=[1, 1],
-                    dynamics=KinematicBicycleDynamics(
+                    dynamics=KinematicBicycle(
                         world,
                         width=width,
                         l_f=l_f,
@@ -65,7 +65,7 @@ class Scenario(BaseScenario):
                     render_action=True,
                     u_range=[1, 1, 1],
                     u_multiplier=[1, 1, 0.001],
-                    dynamics=HolonomicWithRotationDynamics(),
+                    dynamics=HolonomicWithRotation(),
                 )
 
             world.add_agent(agent)

--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 
@@ -7,10 +7,13 @@ from __future__ import annotations
 import math
 import typing
 from abc import ABC, abstractmethod
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Union, Sequence
 
 import torch
 from torch import Tensor
+
+from vmas.simulator.dynamics.common import Dynamics
+from vmas.simulator.dynamics.holonomic import HolonomicDynamics
 from vmas.simulator.joints import Joint
 from vmas.simulator.physics import (
     _get_closest_point_line,
@@ -308,6 +311,10 @@ class AgentState(EntityState):
         super().__init__()
         # communication utterance
         self._c = None
+        # Agent force from actions
+        self._force = None
+        # Agent torque from actions
+        self._torque = None
 
     @property
     def c(self):
@@ -324,9 +331,39 @@ class AgentState(EntityState):
 
         self._c = c.to(self._device)
 
+    @property
+    def force(self):
+        return self._force
+
+    @force.setter
+    def force(self, value):
+        assert (
+            self._batch_dim is not None and self._device is not None
+        ), "First add an entity to the world before setting its state"
+        assert (
+            value.shape[0] == self._batch_dim
+        ), f"Internal state must match batch dim, got {value.shape[0]}, expected {self._batch_dim}"
+
+        self._force = value.to(self._device)
+
+    @property
+    def torque(self):
+        return self._torque
+
+    @torque.setter
+    def torque(self, value):
+        assert (
+            self._batch_dim is not None and self._device is not None
+        ), "First add an entity to the world before setting its state"
+        assert (
+            value.shape[0] == self._batch_dim
+        ), f"Internal state must match batch dim, got {value.shape[0]}, expected {self._batch_dim}"
+
+        self._torque = value.to(self._device)
+
     @override(EntityState)
     def _reset(self, env_index: typing.Optional[int]):
-        for attr in [self.c]:
+        for attr in [self.c, self.force, self.torque]:
             if attr is not None:
                 if env_index is None:
                     attr[:] = 0.0
@@ -340,6 +377,12 @@ class AgentState(EntityState):
             self.c = torch.zeros(
                 self.batch_dim, dim_c, device=self.device, dtype=torch.float32
             )
+        self.force = torch.zeros(
+            self.batch_dim, dim_p, device=self.device, dtype=torch.float32
+        )
+        self.torque = torch.zeros(
+            self.batch_dim, 1, device=self.device, dtype=torch.float32
+        )
         super()._spawn(dim_c, dim_p)
 
 
@@ -347,12 +390,10 @@ class AgentState(EntityState):
 class Action(TorchVectorizedObject):
     def __init__(
         self,
-        u_range: float,
-        u_multiplier: float,
-        u_noise: float,
-        u_rot_range: float,
-        u_rot_multiplier: float,
-        u_rot_noise: float,
+        u_range: Union[float, Sequence[float]],
+        u_multiplier: Union[float, Sequence[float]],
+        u_noise: Union[float, Sequence[float]],
+        action_size: int,
     ):
         super().__init__()
         # physical motor noise amount
@@ -361,20 +402,27 @@ class Action(TorchVectorizedObject):
         self._u_range = u_range
         # agent action is a force multiplied by this amount
         self._u_multiplier = u_multiplier
-
-        # physical motor noise amount
-        self._u_rot_noise = u_rot_noise
-        # control range
-        self._u_rot_range = u_rot_range
-        # agent action is a force multiplied by this amount
-        self._u_rot_multiplier = u_rot_multiplier
+        # Number of actions
+        self.action_size = action_size
 
         # physical action
         self._u = None
-        # rotation action
-        self._u_rot = None
         # communication_action
         self._c = None
+
+        self._u_range_tensor = None
+        self._u_multiplier_tensor = None
+        self._u_noise_tensor = None
+
+        self._check_action_init()
+
+    def _check_action_init(self):
+        for attr in (self.u_multiplier, self.u_range, self.u_noise):
+            if isinstance(attr, List):
+                assert len(attr) == self.action_size, (
+                    f"Action attributes u_... must be either a float or a list of floats"
+                    f" (one per action) all with same length"
+                )
 
     @property
     def u(self):
@@ -390,21 +438,6 @@ class Action(TorchVectorizedObject):
         ), f"Action must match batch dim, got {u.shape[0]}, expected {self._batch_dim}"
 
         self._u = u.to(self._device)
-
-    @property
-    def u_rot(self):
-        return self._u_rot
-
-    @u_rot.setter
-    def u_rot(self, u_rot: Tensor):
-        assert (
-            self._batch_dim is not None and self._device is not None
-        ), "First add an agent to the world before setting its action"
-        assert (
-            u_rot.shape[0] == self._batch_dim
-        ), f"Action must match batch dim, got {u_rot.shape[0]}, expected {self._batch_dim}"
-
-        self._u_rot = u_rot.to(self._device)
 
     @property
     def c(self):
@@ -434,19 +467,31 @@ class Action(TorchVectorizedObject):
         return self._u_noise
 
     @property
-    def u_rot_range(self):
-        return self._u_rot_range
+    def u_range_tensor(self):
+        if self._u_range_tensor is None:
+            self._u_range_tensor = self._to_tensor(self.u_range)
+        return self._u_range_tensor
 
     @property
-    def u_rot_multiplier(self):
-        return self._u_rot_multiplier
+    def u_multiplier_tensor(self):
+        if self._u_multiplier_tensor is None:
+            self._u_multiplier_tensor = self._to_tensor(self.u_multiplier)
+        return self._u_multiplier_tensor
 
     @property
-    def u_rot_noise(self):
-        return self._u_rot_noise
+    def u_noise_tensor(self):
+        if self._u_noise_tensor is None:
+            self._u_noise_tensor = self._to_tensor(self.u_noise)
+        return self._u_noise_tensor
+
+    def _to_tensor(self, value):
+        return torch.tensor(
+            value if isinstance(value, Sequence) else [value] * self.action_size,
+            device=self.device,
+        )
 
     def _reset(self, env_index: typing.Optional[int]):
-        for attr in [self.u, self.u_rot, self.c]:
+        for attr in [self.u, self.c]:
             if attr is not None:
                 if env_index is None:
                     attr[:] = 0.0
@@ -761,15 +806,12 @@ class Agent(Entity):
         alpha: float = 0.5,
         obs_range: float = None,
         obs_noise: float = None,
-        u_noise: float = None,
-        u_range: float = 1.0,
-        u_multiplier: float = 1.0,
-        u_rot_noise: float = None,
-        u_rot_range: float = 0.0,
-        u_rot_multiplier: float = 1.0,
+        u_noise: Union[float, Sequence[float]] = 0.0,
+        u_range: Union[float, Sequence[float]] = 1.0,
+        u_multiplier: Union[float, Sequence[float]] = 1.0,
         action_script: Callable[[Agent, World], None] = None,
         sensors: List[Sensor] = None,
-        c_noise: float = None,
+        c_noise: float = 0.0,
         silent: bool = True,
         adversary: bool = False,
         drag: float = None,
@@ -778,6 +820,8 @@ class Agent(Entity):
         gravity: float = None,
         collision_filter: Callable[[Entity], bool] = lambda _: True,
         render_action: bool = False,
+        dynamics: Dynamics = None,  # Defaults to holonomic
+        action_size: int = None,
     ):
         super().__init__(
             name,
@@ -827,15 +871,20 @@ class Agent(Entity):
         # Render alpha
         self._alpha = alpha
 
-        # action
+        # Dynamics
+        self.dynamics = dynamics if dynamics is not None else HolonomicDynamics()
+        # Action
+        self.action_size = (
+            action_size if action_size is not None else self.dynamics.needed_action_size
+        )
+        self.dynamics.agent = self
         self._action = Action(
             u_range=u_range,
             u_multiplier=u_multiplier,
             u_noise=u_noise,
-            u_rot_range=u_rot_range,
-            u_rot_multiplier=u_rot_multiplier,
-            u_rot_noise=u_rot_noise,
+            action_size=self.action_size,
         )
+
         # state
         self._state = AgentState()
 
@@ -864,28 +913,15 @@ class Agent(Entity):
         assert (
             self._action.u.shape[1] == world.dim_p
         ), f"Scripted physical action of agent {self.name} has wrong shape"
+
         assert (
-            (self._action.u / self.u_multiplier).abs() <= self.u_range
+            (self._action.u / self.action.u_multiplier_tensor).abs()
+            <= self.action.u_range_tensor
         ).all(), f"Scripted physical action of {self.name} is out of range"
-        if self.u_rot_range != 0:
-            assert (
-                self._action.u_rot is not None
-            ), f"Action script of {self.name} should set u_rot action"
-            assert (
-                self._action.u_rot.shape[1] == 1
-            ), f"Scripted physical rotation action of agent {self.name} has wrong shape"
-            assert (
-                (self._action.u_rot / self._action.u_rot_multiplier).abs()
-                <= self.u_rot_range
-            ).all(), f"Scripted physical rotation action of {self.name} is out of range"
 
     @property
     def u_range(self):
         return self.action.u_range
-
-    @property
-    def u_rot_range(self):
-        return self.action.u_rot_range
 
     @property
     def obs_noise(self):
@@ -898,10 +934,6 @@ class Agent(Entity):
     @property
     def u_multiplier(self):
         return self.action.u_multiplier
-
-    @property
-    def u_rot_multiplier(self):
-        return self.action.u_rot_multiplier
 
     @property
     def max_f(self):
@@ -952,6 +984,7 @@ class Agent(Entity):
     @override(Entity)
     def _reset(self, env_index: int):
         self.action._reset(env_index)
+        self.dynamics.reset(env_index)
         super()._reset(env_index)
 
     @override(Entity)
@@ -973,11 +1006,11 @@ class Agent(Entity):
         if self._sensors is not None:
             for sensor in self._sensors:
                 geoms += sensor.render(env_index=env_index)
-        if self._render_action and self.action.u is not None:
+        if self._render_action and self.state.force is not None:
             velocity = rendering.Line(
                 self.state.pos[env_index],
                 self.state.pos[env_index]
-                + self.action.u[env_index] * 10 * self.shape.circumscribed_radius(),
+                + self.state.force[env_index] * 10 * self.shape.circumscribed_radius(),
                 width=2,
             )
             velocity.set_color(*self.color)
@@ -1503,10 +1536,11 @@ class World(TorchVectorizedObject):
             self.torque[:] = 0
 
             for i, entity in enumerate(self.entities):
-                # apply agent force controls
-                self._apply_action_force(entity, i)
-                # apply agent torque controls
-                self._apply_action_torque(entity, i)
+                if isinstance(entity, Agent):
+                    # apply agent force controls
+                    self._apply_action_force(entity, i)
+                    # apply agent torque controls
+                    self._apply_action_torque(entity, i)
                 # apply friction
                 self._apply_friction_force(entity, i)
                 # apply gravity
@@ -1526,57 +1560,30 @@ class World(TorchVectorizedObject):
                 self._update_comm_state(agent)
 
     # gather agent action forces
-    def _apply_action_force(self, entity: Entity, index: int):
-        if isinstance(entity, Agent):
-            # set applied forces
-            if entity.movable:
-                noise = (
-                    torch.randn(
-                        *entity.action.u.shape, device=self.device, dtype=torch.float32
-                    )
-                    * entity.u_noise
-                    if entity.u_noise
-                    else 0.0
+    def _apply_action_force(self, agent: Agent, index: int):
+        if agent.movable:
+            if agent.max_f is not None:
+                agent.state.force = TorchUtils.clamp_with_norm(
+                    agent.state.force, agent.max_f
                 )
-                entity.action.u += noise
-                if entity.max_f is not None:
-                    entity.action.u = TorchUtils.clamp_with_norm(
-                        entity.action.u, entity.max_f
-                    )
-                if entity.f_range is not None:
-                    entity.action.u = torch.clamp(
-                        entity.action.u, -entity.f_range, entity.f_range
-                    )
-                self.force[:, index] += entity.action.u
-            assert not self.force.isnan().any()
+            if agent.f_range is not None:
+                agent.state.force = torch.clamp(
+                    agent.state.force, -agent.f_range, agent.f_range
+                )
+            self.force[:, index] += agent.state.force
 
-    def _apply_action_torque(self, entity: Entity, index: int):
-        if isinstance(entity, Agent) and entity.u_rot_range != 0:
-            # set applied forces
-            if entity.rotatable:
-                noise = (
-                    torch.randn(
-                        *entity.action.u_rot.shape,
-                        device=self.device,
-                        dtype=torch.float32,
-                    )
-                    * entity.action.u_rot_noise
-                    if entity.action.u_rot_noise
-                    else 0.0
+    def _apply_action_torque(self, agent: Agent, index: int):
+        if agent.rotatable:
+            if agent.max_t is not None:
+                agent.state.torque = TorchUtils.clamp_with_norm(
+                    agent.state.torque, agent.max_t
                 )
-                entity.action.u_rot = entity.action.u_rot + noise
-                if len(entity.action.u_rot.shape) == 1:
-                    entity.action.u_rot.unsqueeze_(-1)
-                if entity.max_t is not None:
-                    entity.action.u_rot = TorchUtils.clamp_with_norm(
-                        entity.action.u_rot, entity.max_t
-                    )
-                if entity.t_range is not None:
-                    entity.action.u_rot = torch.clamp(
-                        entity.action.u_rot, -entity.t_range, entity.t_range
-                    )
-                self.torque[:, index] += entity.action.u_rot
-            assert not self.torque.isnan().any()
+            if agent.t_range is not None:
+                agent.state.torque = torch.clamp(
+                    agent.state.torque, -agent.t_range, agent.t_range
+                )
+
+            self.torque[:, index] += agent.state.torque
 
     def _apply_gravity(self, entity: Entity, index: int):
         if entity.movable:
@@ -2387,15 +2394,7 @@ class World(TorchVectorizedObject):
     def _update_comm_state(self, agent):
         # set communication state (directly for now)
         if not agent.silent:
-            noise = (
-                torch.randn(
-                    *agent.action.c.shape, device=self.device, dtype=torch.float32
-                )
-                * agent.c_noise
-                if agent.c_noise
-                else 0.0
-            )
-            agent.state.c = agent.action.c + noise
+            agent.state.c = agent.action.c
 
     @override(TorchVectorizedObject)
     def to(self, device: torch.device):

--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -13,7 +13,7 @@ import torch
 from torch import Tensor
 
 from vmas.simulator.dynamics.common import Dynamics
-from vmas.simulator.dynamics.holonomic import HolonomicDynamics
+from vmas.simulator.dynamics.holonomic import Holonomic
 from vmas.simulator.joints import Joint
 from vmas.simulator.physics import (
     _get_closest_point_line,
@@ -872,7 +872,7 @@ class Agent(Entity):
         self._alpha = alpha
 
         # Dynamics
-        self.dynamics = dynamics if dynamics is not None else HolonomicDynamics()
+        self.dynamics = dynamics if dynamics is not None else Holonomic()
         # Action
         self.action_size = (
             action_size if action_size is not None else self.dynamics.needed_action_size

--- a/vmas/simulator/dynamics/common.py
+++ b/vmas/simulator/dynamics/common.py
@@ -1,0 +1,45 @@
+#  Copyright (c) 2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+import abc
+from abc import ABC
+from typing import Union
+
+from torch import Tensor
+
+
+class Dynamics(ABC):
+    def __init__(
+        self,
+    ):
+        self._agent = None
+
+    def reset(self, index: Union[Tensor, int] = None):
+        pass
+
+    @property
+    def agent(self):
+        if self._agent is None:
+            raise ValueError(
+                "You need to add the dynamics to an agent during construction before accessing its properties"
+            )
+        return self._agent
+
+    @agent.setter
+    def agent(self, value):
+        if self._agent is not None:
+            raise ValueError("Agent in dynamics has already been set")
+        if value.action_size < self.needed_action_size:
+            raise ValueError(
+                f"Agent action size {value.action_size} is less than the required dynamics action size {self.needed_action_size}"
+            )
+        self._agent = value
+
+    @property
+    @abc.abstractmethod
+    def needed_action_size(self) -> int:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def process_action(self):
+        raise NotImplementedError

--- a/vmas/simulator/dynamics/diff_drive.py
+++ b/vmas/simulator/dynamics/diff_drive.py
@@ -10,7 +10,7 @@ import vmas.simulator.utils
 from vmas.simulator.dynamics.common import Dynamics
 
 
-class DiffDriveDynamics(Dynamics):
+class DiffDrive(Dynamics):
     def __init__(
         self,
         world: vmas.simulator.core.World,

--- a/vmas/simulator/dynamics/diff_drive.py
+++ b/vmas/simulator/dynamics/diff_drive.py
@@ -1,34 +1,27 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 import math
-from typing import Union
 
 import torch
-from torch import Tensor
+
 import vmas.simulator.core
 import vmas.simulator.utils
+from vmas.simulator.dynamics.common import Dynamics
 
 
-class DiffDriveDynamics:
+class DiffDriveDynamics(Dynamics):
     def __init__(
         self,
-        agent: vmas.simulator.core.Agent,
         world: vmas.simulator.core.World,
         integration: str = "rk4",  # one of "euler", "rk4"
     ):
+        super().__init__()
         assert integration == "rk4" or integration == "euler"
-        assert (
-            agent.action.u_rot_range != 0
-        ), "Agent with diff drive dynamics needs non zero u_rot_range"
 
-        self.agent = agent
-        self.world = world
         self.dt = world.dt
         self.integration = integration
-
-    def reset(self, index: Union[Tensor, int] = None):
-        pass
+        self.world = world
 
     def euler(self, f, rot):
         return f(rot)
@@ -41,9 +34,13 @@ class DiffDriveDynamics:
 
         return (1 / 6) * (k1 + 2 * k2 + 2 * k3 + k4)
 
-    def process_force(self):
-        u_forward = self.agent.action.u[:, vmas.simulator.utils.X]
-        u_rot = self.agent.action.u_rot.squeeze(-1)
+    @property
+    def needed_action_size(self) -> int:
+        return 2
+
+    def process_action(self):
+        u_forward = self.agent.action.u[:, 0]
+        u_rot = self.agent.action.u[:, 1]
 
         def f(rot):
             return torch.stack(
@@ -55,5 +52,6 @@ class DiffDriveDynamics:
         else:
             u = self.runge_kutta(f, self.agent.state.rot.squeeze(-1))
 
-        self.agent.action.u[:, vmas.simulator.utils.X] = u[vmas.simulator.utils.X]
-        self.agent.action.u[:, vmas.simulator.utils.Y] = u[vmas.simulator.utils.Y]
+        self.agent.state.force[:, vmas.simulator.utils.X] = u[vmas.simulator.utils.X]
+        self.agent.state.force[:, vmas.simulator.utils.Y] = u[vmas.simulator.utils.Y]
+        self.agent.state.torque = u_rot.unsqueeze(-1)

--- a/vmas/simulator/dynamics/holonomic.py
+++ b/vmas/simulator/dynamics/holonomic.py
@@ -1,0 +1,14 @@
+#  Copyright (c) 2022-2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+
+from vmas.simulator.dynamics.common import Dynamics
+
+
+class HolonomicDynamics(Dynamics):
+    @property
+    def needed_action_size(self) -> int:
+        return 2
+
+    def process_action(self):
+        self.agent.state.force = self.agent.action.u[:, : self.needed_action_size]

--- a/vmas/simulator/dynamics/holonomic.py
+++ b/vmas/simulator/dynamics/holonomic.py
@@ -5,7 +5,7 @@
 from vmas.simulator.dynamics.common import Dynamics
 
 
-class HolonomicDynamics(Dynamics):
+class Holonomic(Dynamics):
     @property
     def needed_action_size(self) -> int:
         return 2

--- a/vmas/simulator/dynamics/holonomic_with_rot.py
+++ b/vmas/simulator/dynamics/holonomic_with_rot.py
@@ -5,7 +5,7 @@
 from vmas.simulator.dynamics.common import Dynamics
 
 
-class HolonomicWithRotationDynamics(Dynamics):
+class HolonomicWithRotation(Dynamics):
     @property
     def needed_action_size(self) -> int:
         return 3

--- a/vmas/simulator/dynamics/holonomic_with_rot.py
+++ b/vmas/simulator/dynamics/holonomic_with_rot.py
@@ -1,0 +1,15 @@
+#  Copyright (c) 2022-2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+
+from vmas.simulator.dynamics.common import Dynamics
+
+
+class HolonomicWithRotationDynamics(Dynamics):
+    @property
+    def needed_action_size(self) -> int:
+        return 3
+
+    def process_action(self):
+        self.agent.state.force = self.agent.action.u[:, :2]
+        self.agent.state.torque = self.agent.action.u[:, 2].unsqueeze(-1)

--- a/vmas/simulator/dynamics/kinematic_bicycle.py
+++ b/vmas/simulator/dynamics/kinematic_bicycle.py
@@ -11,7 +11,7 @@ import vmas.simulator.utils
 from vmas.simulator.dynamics.common import Dynamics
 
 
-class KinematicBicycleDynamics(Dynamics):
+class KinematicBicycle(Dynamics):
     # For the implementation of the kinematic bicycle model, see the equation (2) of the paper Polack, Philip, et al. "The kinematic bicycle model: A consistent model for planning feasible trajectories for autonomous vehicles?." 2017 IEEE intelligent vehicles symposium (IV). IEEE, 2017.
     def __init__(
         self,

--- a/vmas/simulator/dynamics/kinematic_bicycle.py
+++ b/vmas/simulator/dynamics/kinematic_bicycle.py
@@ -1,21 +1,20 @@
-#  Copyright (c) 2023.
+#  Copyright (c) 2023-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 
 from typing import Union
 
 import torch
-from torch import Tensor
 
 import vmas.simulator.core
 import vmas.simulator.utils
+from vmas.simulator.dynamics.common import Dynamics
 
 
-class KinematicBicycleDynamics:
+class KinematicBicycleDynamics(Dynamics):
     # For the implementation of the kinematic bicycle model, see the equation (2) of the paper Polack, Philip, et al. "The kinematic bicycle model: A consistent model for planning feasible trajectories for autonomous vehicles?." 2017 IEEE intelligent vehicles symposium (IV). IEEE, 2017.
     def __init__(
         self,
-        agent: vmas.simulator.core.Agent,
         world: vmas.simulator.core.World,
         width: float,
         l_f: float,
@@ -23,21 +22,18 @@ class KinematicBicycleDynamics:
         max_steering_angle: float,
         integration: str = "euler",  # one of "euler", "rk4"
     ):
+        super().__init__()
         assert integration in (
             "rk4",
             "euler",
         ), "Integration method must be 'euler' or 'rk4'."
-        self.agent = agent
-        self.world = world
         self.width = width
         self.l_f = l_f  # Distance between the front axle and the center of gravity
         self.l_r = l_r  # Distance between the rear axle and the center of gravity
         self.max_steering_angle = max_steering_angle
         self.dt = world.dt
         self.integration = integration
-
-    def reset(self, index: Union[Tensor, int] = None):
-        pass
+        self.world = world
 
     def euler(self, f, state):
         # Update the state using Euler's method
@@ -53,10 +49,15 @@ class KinematicBicycleDynamics:
         k4 = f(state + self.dt * k3)
         return state + (self.dt / 6) * (k1 + 2 * k2 + 2 * k3 + k4)
 
-    def process_force(self):
+    @property
+    def needed_action_size(self) -> int:
+        return 2
+
+    def process_action(self):
         # Extracts the velocity and steering angle from the agent's actions and convert them to physical force and torque
-        velocity = self.agent.action.u[:, vmas.simulator.utils.X]
-        steering_angle = self.agent.action.u_rot.squeeze(-1)
+        velocity = self.agent.action.u[:, 0]
+        steering_angle = self.agent.action.u[:, 1]
+
         # Ensure steering angle is within bounds
         steering_angle = torch.clamp(
             steering_angle, -self.max_steering_angle, self.max_steering_angle
@@ -99,6 +100,6 @@ class KinematicBicycleDynamics:
         torque = self.agent.moment_of_inertia * angular_acceleration
 
         # Update the physical force and torque required for the user inputs
-        self.agent.action.u[:, vmas.simulator.utils.X] = force_x
-        self.agent.action.u[:, vmas.simulator.utils.Y] = force_y
-        self.agent.action.u_rot[:, 0] = torque
+        self.agent.state.force[:, vmas.simulator.utils.X] = force_x
+        self.agent.state.force[:, vmas.simulator.utils.Y] = force_y
+        self.agent.state.torque = torque.unsqueeze(-1)

--- a/vmas/simulator/environment/environment.py
+++ b/vmas/simulator/environment/environment.py
@@ -45,6 +45,11 @@ class Environment(TorchVectorizedObject):
         multidiscrete_actions: bool = False,
         **kwargs,
     ):
+        if multidiscrete_actions:
+            assert (
+                not continuous_actions
+            ), "When asking for multidiscrete_actions, make sure continuous_actions=False"
+
         self.scenario = scenario
         self.num_envs = num_envs
         TorchVectorizedObject.__init__(self, num_envs, torch.device(device))

--- a/vmas/simulator/environment/environment.py
+++ b/vmas/simulator/environment/environment.py
@@ -42,7 +42,7 @@ class Environment(TorchVectorizedObject):
         continuous_actions: bool = True,
         seed: Optional[int] = None,
         dict_spaces: bool = False,
-        multidiscrete: bool = False,
+        multidiscrete_actions: bool = False,
         **kwargs,
     ):
         self.scenario = scenario
@@ -59,7 +59,7 @@ class Environment(TorchVectorizedObject):
         self.reset(seed=seed)
 
         # configure spaces
-        self.multidiscrete = multidiscrete
+        self.multidiscrete_actions = multidiscrete_actions
         self.action_space = self.get_action_space()
         self.observation_space = self.get_observation_space()
 
@@ -298,7 +298,7 @@ class Environment(TorchVectorizedObject):
             return agent.action.action_size + (
                 self.world.dim_c if not agent.silent else 0
             )
-        elif self.multidiscrete:
+        elif self.multidiscrete_actions:
             return agent.action_size + (
                 1 if not agent.silent and self.world.dim_c != 0 else 0
             )
@@ -321,7 +321,7 @@ class Environment(TorchVectorizedObject):
                 shape=(self.get_agent_action_size(agent),),
                 dtype=np.float32,
             )
-        elif self.multidiscrete:
+        elif self.multidiscrete_actions:
             actions = [3] * agent.action_size + (
                 [self.world.dim_c] if not agent.silent and self.world.dim_c != 0 else []
             )
@@ -386,7 +386,7 @@ class Environment(TorchVectorizedObject):
             agent.action.u = physical_action.to(torch.float32)
 
         else:
-            if not self.multidiscrete:
+            if not self.multidiscrete_actions:
                 # This bit of code translates the discrete action (taken from a space that
                 # is the cartesian product of all action spaces) into a multi discrete action.
                 # For example, if agent.action_size=4, it will mean that the agent will have

--- a/vmas/simulator/environment/environment.py
+++ b/vmas/simulator/environment/environment.py
@@ -42,6 +42,7 @@ class Environment(TorchVectorizedObject):
         continuous_actions: bool = True,
         seed: Optional[int] = None,
         dict_spaces: bool = False,
+        multidiscrete: bool = False,
         **kwargs,
     ):
         self.scenario = scenario
@@ -58,7 +59,7 @@ class Environment(TorchVectorizedObject):
         self.reset(seed=seed)
 
         # configure spaces
-        self.multidiscrete = False
+        self.multidiscrete = multidiscrete
         self.action_space = self.get_action_space()
         self.observation_space = self.get_observation_space()
 
@@ -387,7 +388,7 @@ class Environment(TorchVectorizedObject):
         else:
             if not self.multidiscrete:
                 # This bit of code translates the discrete action (taken from a space that
-                # is the cross product of all action spaces) into a multi discrete action.
+                # is the cartesian product of all action spaces) into a multi discrete action.
                 # For example, if agent.action_size=4, it will mean that the agent will have
                 # 4 actions each with 3 possibilities (stay, decrement, increment).
                 # The env will have a space Discrete(3**4).

--- a/vmas/simulator/environment/environment.py
+++ b/vmas/simulator/environment/environment.py
@@ -307,22 +307,12 @@ class Environment(TorchVectorizedObject):
             return spaces.Box(
                 low=np.array(
                     (-agent.action.u_range_tensor).tolist()
-                    + [0]
-                    * (
-                        self.world.dim_c
-                        if not agent.silent and self.world.dim_c != 0
-                        else 0
-                    ),
+                    + [0] * (self.world.dim_c if not agent.silent else 0),
                     dtype=np.float32,
                 ),
                 high=np.array(
                     agent.action.u_range_tensor.tolist()
-                    + [1]
-                    * (
-                        self.world.dim_c
-                        if not agent.silent and self.world.dim_c != 0
-                        else 0
-                    ),
+                    + [1] * (self.world.dim_c if not agent.silent else 0),
                     dtype=np.float32,
                 ),
                 shape=(self.get_agent_action_size(agent),),

--- a/vmas/simulator/scenario.py
+++ b/vmas/simulator/scenario.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 import typing
@@ -63,7 +63,9 @@ class BaseScenario(ABC):
         """Do not override"""
         if agent.action_script is not None:
             agent.action_callback(self.world)
+        # Customizable action processor
         self.process_action(agent)
+        agent.dynamics.process_action()
 
     @abstractmethod
     def make_world(self, batch_dim: int, device: torch.device, **kwargs) -> World:


### PR DESCRIPTION
## New features

- The actions `agent.action.u` (which before corresponed to `agent.state.force`) are now detached from the physics. Dynamics will read actions and write into `agent.state.force` and `agent.state.torque`. This allows users to play around with action sizes and new dynamics more flexibly.
- At agent construction you can specify the agent dynamics (`Agent(dynamics=Holonomic())` is the default). There are many available (`Holonomic,HolonomicWithRotation,DiffDrive,KinematicBicycle`)
- The dynamics will define the action size. You can also override this and define an action size yourself `Agent(action_size=3)`. But you have to provide at least the minimum number of actions required by the dynamics `(dynamics.needed_action_size)`. The dynamics will use the first `dynamics.needed_action_size` actions and the rest can be used for other user needs
- The discrete actions will have 3 options for each `agent.action_size` action. By default the holonomic agent has 2 actions: force_x (with 3 options stay,decrement,increment) and force_y (with 3 options stay,decrement,increment). Holonomic agent with rotations have 3 actions,  with the additional one controlling torque (with the 3 options stay, decrement, increment). And so on for other dynamics....
- Action ranges, multipliers and noise can be controlled at agent construction with `u_range`, `u_multiplier` and `u_noise`. These can either be a scalar or a list. In case of a list, the list must have length `agent.action_size`


## BC-BREAKING Changes

- Removed `u_rot_range`,`u_rot_multiplier` in favor of a more general `u_range`, `u_multiplier` and `u_noise` which can be a list (one elem per action ) 
- Removed MultiDiscrete actions. While before in case of multiple actions there was a space `Multidiscrete([action_1_size, action_2_size]) `, now there is a space  `DIscrete(action_1_size * action_2_size)`. It is still possible to ask MultiDIscrete action spaces by setting `vmas.make_env(multidiscrete_actions=True)`
- Discrete actions for the default dynamics (holonomic no rotation) have changed from 5 (up,down,left,right,stay) to 9, that now include the corners.


FIxes #51
Fixes #75 

cc @Jianye-Xu @Zartris
