### PR TITLE
[NOMRG] Example: mass as Tensor

### DIFF
--- a/vmas/examples/use_vmas_env.py
+++ b/vmas/examples/use_vmas_env.py
@@ -152,7 +152,7 @@ def use_vmas_env(
 
 if __name__ == "__main__":
     use_vmas_env(
-        scenario_name="waterfall",
+        scenario_name="navigation",
         render=True,
         save_render=False,
         random_action=False,

--- a/vmas/scenarios/navigation.py
+++ b/vmas/scenarios/navigation.py
@@ -98,6 +98,7 @@ class Scenario(BaseScenario):
                 ]
                 if self.collisions
                 else None,
+                mass=torch.ones(batch_dim, 1, device=device, dtype=torch.float),
             )
             agent.pos_rew = torch.zeros(batch_dim, device=device)
             agent.agent_collision_rew = agent.pos_rew.clone()

--- a/vmas/scenarios/navigation.py
+++ b/vmas/scenarios/navigation.py
@@ -98,7 +98,7 @@ class Scenario(BaseScenario):
                 ]
                 if self.collisions
                 else None,
-                mass=torch.ones(batch_dim, 1, device=device, dtype=torch.float),
+                mass=torch.randn(batch_dim, 1, device=device, dtype=torch.float),
             )
             agent.pos_rew = torch.zeros(batch_dim, device=device)
             agent.agent_collision_rew = agent.pos_rew.clone()

--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -11,6 +11,7 @@ from typing import Callable, List, Tuple, Union, Sequence
 
 import torch
 from torch import Tensor
+
 from vmas.simulator.dynamics.common import Dynamics
 from vmas.simulator.dynamics.holonomic import Holonomic
 from vmas.simulator.joints import Joint
@@ -508,7 +509,7 @@ class Entity(TorchVectorizedObject, Observable, ABC):
         rotatable: bool = False,
         collide: bool = True,
         density: float = 25.0,  # Unused for now
-        mass: float = 1.0,
+        mass: Union[float, Tensor] = 1.0,
         shape: Shape = Sphere(),
         v_range: float = None,
         max_speed: float = None,
@@ -754,7 +755,7 @@ class Landmark(Entity):
         rotatable: bool = False,
         collide: bool = True,
         density: float = 25.0,  # Unused for now
-        mass: float = 1.0,
+        mass: Union[float, Tensor] = 1.0,
         v_range: float = None,
         max_speed: float = None,
         color=Color.GRAY,
@@ -795,7 +796,7 @@ class Agent(Entity):
         rotatable: bool = True,
         collide: bool = True,
         density: float = 25.0,  # Unused for now
-        mass: float = 1.0,
+        mass: Union[float, Tensor] = 1.0,
         f_range: float = None,
         max_f: float = None,
         t_range: float = None,
@@ -821,7 +822,7 @@ class Agent(Entity):
         collision_filter: Callable[[Entity], bool] = lambda _: True,
         render_action: bool = False,
         dynamics: Dynamics = None,  # Defaults to holonomic
-        action_size: int = None,
+        action_size: int = None,  # Defaults to what required by the dynamics
     ):
         super().__init__(
             name,

--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -822,7 +822,7 @@ class Agent(Entity):
         collision_filter: Callable[[Entity], bool] = lambda _: True,
         render_action: bool = False,
         dynamics: Dynamics = None,  # Defaults to holonomic
-        action_size: int = None,  # Defaults to what required by the dynamics
+        action_size: int = None,
     ):
         super().__init__(
             name,


### PR DESCRIPTION
cc @LukasSchaefer

If you look at the files changed, here is an example of setting mass to a tensor (that is different for each env) in the `navigation` scenario

To run the scenario you can use 
```
python vmas/examples/use_vmas_env.py
```
in this branch

It just happens to work out of the box for this case.

If you experience cases where it is not working out of the box let me know and we can fix them.
Based on what you need we can tackle one attribute at a time to allow them to be union of float and tensor