### PR TITLE
[Bug] Package mass arg now passed into constructor

### DIFF
--- a/vmas/scenarios/reverse_transport.py
+++ b/vmas/scenarios/reverse_transport.py
@@ -45,7 +45,7 @@ class Scenario(BaseScenario):
             name=f"package {i}",
             collide=True,
             movable=True,
-            mass=50,
+            mass=self.package_mass,
             shape=Box(
                 length=self.package_length,
                 width=self.package_width,

--- a/vmas/scenarios/transport.py
+++ b/vmas/scenarios/transport.py
@@ -56,7 +56,7 @@ class Scenario(BaseScenario):
                 name=f"package {i}",
                 collide=True,
                 movable=True,
-                mass=50,
+                mass=self.package_mass,
                 shape=Box(length=self.package_length, width=self.package_width),
                 color=Color.RED,
             )


### PR DESCRIPTION
Previously in transport and reverse_transport the package mass was hardcoded to 50, regardless of the value of self.package_mass.

cc @matteobettini 