### PR TITLE
[Feat] Render lidar before agents and allow for tuple as color

### DIFF
--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -1045,14 +1045,11 @@ class Agent(Entity):
         geoms = super().render(env_index)
         if len(geoms) == 0:
             return geoms
-
+        for geom in geoms:
+            geom.set_color(*self.color, alpha=self._alpha)
         if self._sensors is not None:
             for sensor in self._sensors:
                 geoms += sensor.render(env_index=env_index)
-
-        for geom in geoms:
-            geom.set_color(*self.color, alpha=self._alpha)
-
         if self._render_action and self.state.force is not None:
             velocity = rendering.Line(
                 self.state.pos[env_index],
@@ -1830,10 +1827,7 @@ class World(TorchVectorizedObject):
             )
             rotate = rotate_prior.unsqueeze(0).expand(self.batch_dim, -1).unsqueeze(-1)
 
-            (
-                force_a_attractive,
-                force_b_attractive,
-            ) = self._get_constraint_forces(
+            (force_a_attractive, force_b_attractive,) = self._get_constraint_forces(
                 pos_joint_a,
                 pos_joint_b,
                 dist_min=dist,

--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -1045,11 +1045,14 @@ class Agent(Entity):
         geoms = super().render(env_index)
         if len(geoms) == 0:
             return geoms
-        for geom in geoms:
-            geom.set_color(*self.color, alpha=self._alpha)
+
         if self._sensors is not None:
             for sensor in self._sensors:
                 geoms += sensor.render(env_index=env_index)
+
+        for geom in geoms:
+            geom.set_color(*self.color, alpha=self._alpha)
+
         if self._render_action and self.state.force is not None:
             velocity = rendering.Line(
                 self.state.pos[env_index],
@@ -1827,7 +1830,10 @@ class World(TorchVectorizedObject):
             )
             rotate = rotate_prior.unsqueeze(0).expand(self.batch_dim, -1).unsqueeze(-1)
 
-            (force_a_attractive, force_b_attractive,) = self._get_constraint_forces(
+            (
+                force_a_attractive,
+                force_b_attractive,
+            ) = self._get_constraint_forces(
                 pos_joint_a,
                 pos_joint_b,
                 dist_min=dist,

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -139,6 +139,7 @@ class Lidar(Sensor):
                 ray.set_color(*Color.BLACK.value, alpha=self.alpha)
 
                 ray_circ = rendering.make_circle(0.01)
+                ray_circ.set_color(*self.render_color, alpha=self.alpha)
                 xform = rendering.Transform()
                 rot = torch.stack([torch.cos(angle), torch.sin(angle)], dim=-1)
                 pos_circ = (

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -53,7 +53,8 @@ class Lidar(Sensor):
         n_rays: int = 8,
         max_range: float = 1.0,
         entity_filter: Callable[[vmas.simulator.core.Entity], bool] = lambda _: True,
-        render_color: Union[Color, Tuple] = Color.GRAY,
+        render_color: Union[Color, Tuple[float, float, float]] = Color.GRAY,
+        alpha: float = 1.0,
         render: bool = True,
     ):
         super().__init__(world)
@@ -72,6 +73,7 @@ class Lidar(Sensor):
         self._render = render
         self._entity_filter = entity_filter
         self._render_color = render_color
+        self._alpha = alpha
 
     def to(self, device: torch.device):
         self._angles = self._angles.to(device)
@@ -91,6 +93,10 @@ class Lidar(Sensor):
         if isinstance(self._render_color, Color):
             return self._render_color.value
         return self._render_color
+
+    @property
+    def alpha(self):
+        return self._alpha
 
     def measure(self):
         dists = []
@@ -130,7 +136,7 @@ class Lidar(Sensor):
                 xform.set_translation(*self.agent.state.pos[env_index])
                 xform.set_rotation(angle)
                 ray.add_attr(xform)
-                ray.set_color(*self.render_color)
+                ray.set_color(*self.render_color, alpha=self.alpha)
 
                 ray_circ = rendering.make_circle(0.01)
                 xform = rendering.Transform()

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -136,7 +136,7 @@ class Lidar(Sensor):
                 xform.set_translation(*self.agent.state.pos[env_index])
                 xform.set_rotation(angle)
                 ray.add_attr(xform)
-                ray.set_color(*self.render_color, alpha=self.alpha)
+                ray.set_color(*Color.BLACK.value, alpha=self.alpha)
 
                 ray_circ = rendering.make_circle(0.01)
                 xform = rendering.Transform()

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -11,7 +11,6 @@ from typing import Callable, List, Tuple, Union
 import torch
 
 import vmas.simulator.core
-import vmas.simulator.utils
 from vmas.simulator.utils import Color
 
 if typing.TYPE_CHECKING:

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -130,9 +130,9 @@ class Lidar(Sensor):
                 xform.set_translation(*self.agent.state.pos[env_index])
                 xform.set_rotation(angle)
                 ray.add_attr(xform)
+                ray.set_color(*self.render_color)
 
                 ray_circ = rendering.make_circle(0.01)
-                ray_circ.set_color(*self.render_color)
                 xform = rendering.Transform()
                 rot = torch.stack([torch.cos(angle), torch.sin(angle)], dim=-1)
                 pos_circ = (

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -135,7 +135,7 @@ class Lidar(Sensor):
                 xform.set_translation(*self.agent.state.pos[env_index])
                 xform.set_rotation(angle)
                 ray.add_attr(xform)
-                ray.set_color(*Color.BLACK.value, alpha=self.alpha)
+                ray.set_color(r=0, g=0, b=0, alpha=self.alpha)
 
                 ray_circ = rendering.make_circle(0.01)
                 ray_circ.set_color(*self.render_color, alpha=self.alpha)

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 
 import typing
 from abc import ABC, abstractmethod
-from typing import Callable, List, Union
+from typing import Callable, List, Tuple, Union
 
 import torch
 
 import vmas.simulator.core
 import vmas.simulator.utils
+from vmas.simulator.utils import Color
 
 if typing.TYPE_CHECKING:
     from vmas.simulator.rendering import Geom
@@ -52,7 +53,7 @@ class Lidar(Sensor):
         n_rays: int = 8,
         max_range: float = 1.0,
         entity_filter: Callable[[vmas.simulator.core.Entity], bool] = lambda _: True,
-        render_color: vmas.simulator.utils.Color = vmas.simulator.utils.Color.GRAY,
+        render_color: Union[Color, Tuple] = Color.GRAY,
         render: bool = True,
     ):
         super().__init__(world)
@@ -84,6 +85,12 @@ class Lidar(Sensor):
         self, entity_filter: Callable[[vmas.simulator.core.Entity], bool]
     ):
         self._entity_filter = entity_filter
+
+    @property
+    def render_color(self):
+        if isinstance(self._render_color, Color):
+            return self._render_color.value
+        return self._render_color
 
     def measure(self):
         dists = []
@@ -125,7 +132,7 @@ class Lidar(Sensor):
                 ray.add_attr(xform)
 
                 ray_circ = rendering.make_circle(0.01)
-                ray_circ.set_color(*self._render_color.value)
+                ray_circ.set_color(*self.render_color)
                 xform = rendering.Transform()
                 rot = torch.stack([torch.cos(angle), torch.sin(angle)], dim=-1)
                 pos_circ = (


### PR DESCRIPTION

![image](https://github.com/proroklab/VectorizedMultiAgentSimulator/assets/14197299/f72ce46c-2249-4098-931e-487abd6d1017)
Her is an image of my problem. 

When lidar is rendered after the agent geom, it is hard to see the shape of the agent. 

I have two methods for solving this.
1. Render lidar before the agent, hence we can see the agent being rendered on top.
2. Like in the Agent class, we make a getter function for color, that checks if it is an Enum or a tuple. This allows the user to specify an alpha on the lidar color. The downside of this is the user needs to understand that this color tuple needs to be 3 or 4 values, whereas before this was more restricted. But as this is the same as we do in the Agent class I do not see the big harm.

These are small changes that should not break anything.