### PR TITLE
[Feature] different number of actions for each action dimension (discrete actions)

### DIFF
--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -862,6 +862,7 @@ class Agent(Entity):
         render_action: bool = False,
         dynamics: Dynamics = None,  # Defaults to holonomic
         action_size: int = None,  # Defaults to what required by the dynamics
+        action_nvec: list = None,  # Defaults to what required by the dynamics
     ):
         super().__init__(
             name,
@@ -883,6 +884,16 @@ class Agent(Entity):
         )
         if obs_range == 0.0:
             assert sensors is None, f"Blind agent cannot have sensors, got {sensors}"
+
+        # Make sure action size and nvec are consistent
+        # if action_size is not None and action_nvec is not None:
+        #     raise ValueError(f'Cannot specify both action_size and action_nvec')
+        if action_nvec is not None:
+            action_nvec = list(action_nvec)
+        if action_nvec is not None and action_size is None:
+            action_nvec = len(action_nvec)
+        if action_size is not None and action_nvec is None:
+            action_nvec = [3] * action_size
 
         # cannot observe the world
         self._obs_range = obs_range
@@ -916,6 +927,9 @@ class Agent(Entity):
         # Action
         self.action_size = (
             action_size if action_size is not None else self.dynamics.needed_action_size
+        )
+        self.action_nvec = (
+            action_nvec if action_nvec is not None else self.dynamics.action_nvec
         )
         self.dynamics.agent = self
         self._action = Action(

--- a/vmas/simulator/dynamics/common.py
+++ b/vmas/simulator/dynamics/common.py
@@ -5,6 +5,7 @@ import abc
 from abc import ABC
 from typing import Union
 
+import torch
 from torch import Tensor
 
 
@@ -42,10 +43,31 @@ class Dynamics(ABC):
             )
         self.process_action()
 
+    @classmethod
+    def __init_subclass__(cls) -> None:
+        if (cls.needed_action_size is Dynamics.needed_action_size) == (
+            cls.action_nvec is Dynamics.action_nvec
+        ):
+            raise TypeError(
+                "Dynamics subclasses must override exactly one of needed_action_size or action_nvec."
+            )
+        super().__init_subclass__()
+
     @property
-    @abc.abstractmethod
     def needed_action_size(self) -> int:
-        raise NotImplementedError
+        """The size of the action vector needed by the dynamics.
+
+        If not overridden, defaults to the size of the action_nvec."""
+        return len(self.action_nvec)
+
+    @property
+    def action_nvec(self) -> list:
+        """The number of possible values for the discrete version of each action.
+
+        If not overridden, defaults to a list of 3s of length action_size,
+        which results in the mapping [0, 1, 2] -> [-u_range, 0, u_range] for
+        each action."""
+        return [3] * self.needed_action_size
 
     @abc.abstractmethod
     def process_action(self):

--- a/vmas/simulator/dynamics/composite.py
+++ b/vmas/simulator/dynamics/composite.py
@@ -1,0 +1,45 @@
+import torch
+
+from vmas.simulator.dynamics.common import Dynamics
+
+
+class Composite(Dynamics):
+
+    def __init__(self, *dynamics):
+        super().__init__()
+        self.dynamics = dynamics
+
+    # Same as Dyanmics.agent, copied just to allow overriding the setter below
+    @property
+    def agent(self):
+        if self._agent is None:
+            raise ValueError(
+                "You need to add the dynamics to an agent during construction before accessing its properties"
+            )
+        return self._agent
+
+    @agent.setter
+    def agent(self, value):
+        if self._agent is not None:
+            raise ValueError("Agent in dynamics has already been set")
+        self._agent = value
+        # Also set the agent in all the sub-dynamics
+        for dynamics in self.dynamics:
+            dynamics.agent = value
+
+    @property
+    def action_nvec(self):
+        return torch.cat([dynamics.action_nvec for dynamics in self.dynamics], dim=0)
+
+    def process_action(self):
+        # Since we can't pass the action directly to each sub-dynamics, we
+        # temporarily set it to each sub-action and call process_action on
+        # the right sub-dynamics; then we restore the original action.
+        actions = self.agent.action.u
+        a = 0
+        for dynamics in self.dynamics:
+            b = a + dynamics.needed_action_size
+            dynamics.agent.action.u = actions[:, a:b]
+            dynamics.process_action()
+            a = b
+        self.agent.action.u = actions

--- a/vmas/simulator/dynamics/holonomic_with_rot.py
+++ b/vmas/simulator/dynamics/holonomic_with_rot.py
@@ -13,3 +13,12 @@ class HolonomicWithRotation(Dynamics):
     def process_action(self):
         self.agent.state.force = self.agent.action.u[:, :2]
         self.agent.state.torque = self.agent.action.u[:, 2].unsqueeze(-1)
+
+
+class Rotation(Dynamics):
+    @property
+    def needed_action_size(self) -> int:
+        return 1
+
+    def process_action(self):
+        self.agent.state.torque = self.agent.action.u

--- a/vmas/simulator/environment/environment.py
+++ b/vmas/simulator/environment/environment.py
@@ -3,6 +3,7 @@
 #  All rights reserved.
 import random
 from ctypes import byref
+from functools import reduce
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -334,13 +335,13 @@ class Environment(TorchVectorizedObject):
                 dtype=np.float32,
             )
         elif self.multidiscrete_actions:
-            actions = [3] * agent.action_size + (
+            nvec = list(agent.action_nvec) + (
                 [self.world.dim_c] if not agent.silent and self.world.dim_c != 0 else []
             )
-            return spaces.MultiDiscrete(actions)
+            return spaces.MultiDiscrete(nvec)
         else:
             return spaces.Discrete(
-                3**agent.action_size
+                reduce(lambda x, y: x * y, agent.action_nvec, 1)
                 * (
                     self.world.dim_c
                     if not agent.silent and self.world.dim_c != 0
@@ -405,6 +406,25 @@ class Environment(TorchVectorizedObject):
                         )
                     )
             action = torch.stack(actions, dim=-1)
+        elif self.multidiscrete_actions:
+            # from https://github.com/pytorch/pytorch/issues/89438#issuecomment-1862363360
+            def randint(low, high, size, device):
+                return (
+                    torch.randint(2**63 - 1, size=size, device=device) % (high - low)
+                    + low
+                )
+
+            nvec_tensor = torch.tensor(self.get_agent_action_space(agent).nvec) 
+            if torch.any(nvec_tensor > 2**63 - 1):
+                raise ValueError(
+                    "Multidiscrete action spaces with nvec > 2**63 - 1 are not supported"
+                )
+            action = randint(
+                low=0,
+                high=nvec_tensor,
+                size=(agent.batch_dim, len(nvec_tensor)),
+                device=agent.device,
+            )
         else:
             action = torch.randint(
                 low=0,
@@ -438,10 +458,13 @@ class Environment(TorchVectorizedObject):
         """
         return [self.get_random_action(agent) for agent in self.agents]
 
-    def _check_discrete_action(self, action: Tensor, low: int, high: int, type: str):
+    def _check_discrete_action(
+        self, action: Tensor, low: int, high: Union[int, Tensor], type: str
+    ):
+        if not isinstance(high, Tensor):
+            high = torch.tensor(high, device=self.device)
         assert torch.all(
-            (action >= torch.tensor(low, device=self.device))
-            * (action < torch.tensor(high, device=self.device))
+            (action >= torch.tensor(low, device=self.device)) * (action < high)
         ), f"Discrete {type} actions are out of bounds, allowed int range [{low},{high})"
 
     # set env action for a particular agent
@@ -490,41 +513,40 @@ class Environment(TorchVectorizedObject):
             if not self.multidiscrete_actions:
                 # This bit of code translates the discrete action (taken from a space that
                 # is the cartesian product of all action spaces) into a multi discrete action.
-                # For example, if agent.action_size=4, it will mean that the agent will have
-                # 4 actions each with 3 possibilities (stay, decrement, increment).
-                # The env will have a space Discrete(3**4).
-                # This code will translate the action (with shape [n_envs,1] and range [0,3**4)) to an
-                # action with shape [n_envs,4] and range [0,3).
-                n_actions = self.get_agent_action_space(agent).n
-                action_range = torch.arange(n_actions, device=self.device).expand(
-                    self.world.batch_dim, n_actions
+                # This is done by iteratively taking the modulo of the action and dividing by the
+                # number of actions in the current action space, which treats the action as if
+                # it was the "flat index" of the multi-discrete actions. E.g. if we have
+                # action spaces [2, 3, 4], action 0 corresponds to the actions [0, 0, 0],
+                # action 1 corresponds to the action [1, 0, 0], action 2 corresponds
+                # to the action [0, 1, 0], action 3 corresponds to the action [1, 1, 0], etc.
+                flat_action = action.squeeze(-1)
+                actions = []
+                nvec = list(agent.action_nvec) + (
+                    [self.world.dim_c]
+                    if not agent.silent and self.world.dim_c != 0
+                    else []
                 )
-                physical_action = action
-                action_range = torch.where(action_range == physical_action, 1.0, 0.0)
-                action_range = action_range.view(
-                    (self.world.batch_dim,)
-                    + (3,) * agent.action_size
-                    + (self.world.dim_c,)
-                    * (1 if not agent.silent and self.world.dim_c != 0 else 0)
-                )
-                action = action_range.nonzero()[:, 1:]
+                for n in nvec:
+                    actions.append(flat_action % n)
+                    flat_action = flat_action // n
+                action = torch.stack(actions, dim=-1)
 
             # Now we have an action with shape [n_envs, action_size+comms_actions]
-            for _ in range(agent.action_size):
-                physical_action = action[:, action_index].unsqueeze(-1)
+            for n in agent.action_nvec:
+                physical_action = action[:, action_index]
                 self._check_discrete_action(
-                    physical_action,
+                    physical_action.unsqueeze(-1),
                     low=0,
-                    high=3,
+                    high=n,
                     type="physical",
                 )
-
-                arr1 = physical_action == 1
-                arr2 = physical_action == 2
-
-                disc_action_value = agent.action.u_range_tensor[action_index]
-                agent.action.u[:, action_index] -= disc_action_value * arr1.squeeze(-1)
-                agent.action.u[:, action_index] += disc_action_value * arr2.squeeze(-1)
+                u_max = agent.action.u_range_tensor[action_index]
+                # We know u must be in [-u_max, u_max], and we know action is
+                # in [0, n-1]. Conversion steps: [0, n-1] -> [0, 1] -> [0, 2*u_max] -> [-u_max, u_max]
+                # E.g. action 0 -> -u_max, action n-1 -> u_max, action 1 -> -u_max + 2*u_max/(n-1)
+                agent.action.u[:, action_index] = (physical_action / (n - 1)) * (
+                    2 * u_max
+                ) - u_max
 
                 action_index += 1
 


### PR DESCRIPTION
This PR supports specifying different number of actions for each action dimension when the action space is discrete. The motivation is to support action dimensions with different semantics that require different discretizations for each dimension (e.g. combining navigation and "boolean" actions). More in general, this should allow to add any kind of discrete action with arbitrary semantics (also thanks to process_action).

To implement this, I added an `action_nvec` property to `Dynamics`, which is "mutually exclusive" with `needed_action_size`, meaning that if one is overridden the other is computed automatically, and vice-versa (they can't be both overridden). By default, `action_nvec` will be a list of 3s of length `action_size` when not specified, to keep compatibility with existing scenarios. I also added `action_nvec` to the `Agent` class, which is then used in `Environment` to build the discrete action space(s) and in `Environment._set_action` to: 1) convert discrete actions in the interval [0, n) to [-u_max, u_max]; and 2) convert discrete actions to multi-discrete ones when needed.

I also added a `Composite` subclass of `Dynamics` that allows to compose multiple `Dynamics` into one by concatenating their actions, which should make it more convenient (modular) to define complex actions/dynamics.

Let me know if there is anything else that can improve the PR.