### PR TITLE
Vectorized raycast for lidar

### DIFF
--- a/.vscode/PythonImportHelper-v2-Completion.json
+++ b/.vscode/PythonImportHelper-v2-Completion.json
@@ -1,0 +1,7391 @@
+[
+    {
+        "label": "os.path",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "os.path",
+        "description": "os.path",
+        "detail": "os.path",
+        "documentation": {}
+    },
+    {
+        "label": "sys",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "sys",
+        "description": "sys",
+        "detail": "sys",
+        "documentation": {}
+    },
+    {
+        "label": "benchmarl_sphinx_theme",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "benchmarl_sphinx_theme",
+        "description": "benchmarl_sphinx_theme",
+        "detail": "benchmarl_sphinx_theme",
+        "documentation": {}
+    },
+    {
+        "label": "vmas",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "vmas",
+        "description": "vmas",
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "scenarios",
+        "importPath": "vmas",
+        "description": "vmas",
+        "isExtraImport": true,
+        "detail": "vmas",
+        "documentation": {}
+    },
+    {
+        "label": "argparse",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "argparse",
+        "description": "argparse",
+        "detail": "argparse",
+        "documentation": {}
+    },
+    {
+        "label": "os",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "os",
+        "description": "os",
+        "detail": "os",
+        "documentation": {}
+    },
+    {
+        "label": "pickle",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "pickle",
+        "description": "pickle",
+        "detail": "pickle",
+        "documentation": {}
+    },
+    {
+        "label": "platform",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "platform",
+        "description": "platform",
+        "detail": "platform",
+        "documentation": {}
+    },
+    {
+        "label": "re",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "re",
+        "description": "re",
+        "detail": "re",
+        "documentation": {}
+    },
+    {
+        "label": "subprocess",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "subprocess",
+        "description": "subprocess",
+        "detail": "subprocess",
+        "documentation": {}
+    },
+    {
+        "label": "time",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "time",
+        "description": "time",
+        "detail": "time",
+        "documentation": {}
+    },
+    {
+        "label": "pathlib",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "pathlib",
+        "description": "pathlib",
+        "detail": "pathlib",
+        "documentation": {}
+    },
+    {
+        "label": "Path",
+        "importPath": "pathlib",
+        "description": "pathlib",
+        "isExtraImport": true,
+        "detail": "pathlib",
+        "documentation": {}
+    },
+    {
+        "label": "Path",
+        "importPath": "pathlib",
+        "description": "pathlib",
+        "isExtraImport": true,
+        "detail": "pathlib",
+        "documentation": {}
+    },
+    {
+        "label": "numpy",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "numpy",
+        "description": "numpy",
+        "detail": "numpy",
+        "documentation": {}
+    },
+    {
+        "label": "ndarray",
+        "importPath": "numpy",
+        "description": "numpy",
+        "isExtraImport": true,
+        "detail": "numpy",
+        "documentation": {}
+    },
+    {
+        "label": "tikzplotlib",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "tikzplotlib",
+        "description": "tikzplotlib",
+        "detail": "tikzplotlib",
+        "documentation": {}
+    },
+    {
+        "label": "torch",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "torch",
+        "description": "torch",
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "Tensor",
+        "importPath": "torch",
+        "description": "torch",
+        "isExtraImport": true,
+        "detail": "torch",
+        "documentation": {}
+    },
+    {
+        "label": "pyplot",
+        "importPath": "matplotlib",
+        "description": "matplotlib",
+        "isExtraImport": true,
+        "detail": "matplotlib",
+        "documentation": {}
+    },
+    {
+        "label": "pytest",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "pytest",
+        "description": "pytest",
+        "detail": "pytest",
+        "documentation": {}
+    },
+    {
+        "label": "balance",
+        "importPath": "vmas.scenarios",
+        "description": "vmas.scenarios",
+        "isExtraImport": true,
+        "detail": "vmas.scenarios",
+        "documentation": {}
+    },
+    {
+        "label": "discovery",
+        "importPath": "vmas.scenarios",
+        "description": "vmas.scenarios",
+        "isExtraImport": true,
+        "detail": "vmas.scenarios",
+        "documentation": {}
+    },
+    {
+        "label": "flocking",
+        "importPath": "vmas.scenarios",
+        "description": "vmas.scenarios",
+        "isExtraImport": true,
+        "detail": "vmas.scenarios",
+        "documentation": {}
+    },
+    {
+        "label": "transport",
+        "importPath": "vmas.scenarios",
+        "description": "vmas.scenarios",
+        "isExtraImport": true,
+        "detail": "vmas.scenarios",
+        "documentation": {}
+    },
+    {
+        "label": "wheel",
+        "importPath": "vmas.scenarios",
+        "description": "vmas.scenarios",
+        "isExtraImport": true,
+        "detail": "vmas.scenarios",
+        "documentation": {}
+    },
+    {
+        "label": "DEFAULT_ENERGY_COEFF",
+        "importPath": "vmas.scenarios.dropout",
+        "description": "vmas.scenarios.dropout",
+        "isExtraImport": true,
+        "detail": "vmas.scenarios.dropout",
+        "documentation": {}
+    },
+    {
+        "label": "tqdm",
+        "importPath": "tqdm",
+        "description": "tqdm",
+        "isExtraImport": true,
+        "detail": "tqdm",
+        "documentation": {}
+    },
+    {
+        "label": "HeuristicPolicy",
+        "importPath": "vmas.scenarios.navigation",
+        "description": "vmas.scenarios.navigation",
+        "isExtraImport": true,
+        "detail": "vmas.scenarios.navigation",
+        "documentation": {}
+    },
+    {
+        "label": "use_vmas_env",
+        "importPath": "vmas.examples.use_vmas_env",
+        "description": "vmas.examples.use_vmas_env",
+        "isExtraImport": true,
+        "detail": "vmas.examples.use_vmas_env",
+        "documentation": {}
+    },
+    {
+        "label": "typing",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "typing",
+        "description": "typing",
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Optional",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Type",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Callable",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Callable",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Callable",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Callable",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Optional",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Callable",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Optional",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Sequence",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Tuple",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Optional",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Optional",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Tuple",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Callable",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Sequence",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Tuple",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Tuple",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "TYPE_CHECKING",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Callable",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Optional",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Tuple",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Optional",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Callable",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Tuple",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "List",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Sequence",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Tuple",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Dict",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Optional",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "Union",
+        "importPath": "typing",
+        "description": "typing",
+        "isExtraImport": true,
+        "detail": "typing",
+        "documentation": {}
+    },
+    {
+        "label": "ray",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "ray",
+        "description": "ray",
+        "detail": "ray",
+        "documentation": {}
+    },
+    {
+        "label": "tune",
+        "importPath": "ray",
+        "description": "ray",
+        "isExtraImport": true,
+        "detail": "ray",
+        "documentation": {}
+    },
+    {
+        "label": "rllib",
+        "importPath": "ray",
+        "description": "ray",
+        "isExtraImport": true,
+        "detail": "ray",
+        "documentation": {}
+    },
+    {
+        "label": "wandb",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "wandb",
+        "description": "wandb",
+        "detail": "wandb",
+        "documentation": {}
+    },
+    {
+        "label": "BaseEnv",
+        "importPath": "ray.rllib",
+        "description": "ray.rllib",
+        "isExtraImport": true,
+        "detail": "ray.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "Policy",
+        "importPath": "ray.rllib",
+        "description": "ray.rllib",
+        "isExtraImport": true,
+        "detail": "ray.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "RolloutWorker",
+        "importPath": "ray.rllib",
+        "description": "ray.rllib",
+        "isExtraImport": true,
+        "detail": "ray.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "PPOTrainer",
+        "importPath": "ray.rllib.agents.ppo",
+        "description": "ray.rllib.agents.ppo",
+        "isExtraImport": true,
+        "detail": "ray.rllib.agents.ppo",
+        "documentation": {}
+    },
+    {
+        "label": "DefaultCallbacks",
+        "importPath": "ray.rllib.algorithms.callbacks",
+        "description": "ray.rllib.algorithms.callbacks",
+        "isExtraImport": true,
+        "detail": "ray.rllib.algorithms.callbacks",
+        "documentation": {}
+    },
+    {
+        "label": "MultiCallbacks",
+        "importPath": "ray.rllib.algorithms.callbacks",
+        "description": "ray.rllib.algorithms.callbacks",
+        "isExtraImport": true,
+        "detail": "ray.rllib.algorithms.callbacks",
+        "documentation": {}
+    },
+    {
+        "label": "Episode",
+        "importPath": "ray.rllib.evaluation",
+        "description": "ray.rllib.evaluation",
+        "isExtraImport": true,
+        "detail": "ray.rllib.evaluation",
+        "documentation": {}
+    },
+    {
+        "label": "MultiAgentEpisode",
+        "importPath": "ray.rllib.evaluation",
+        "description": "ray.rllib.evaluation",
+        "isExtraImport": true,
+        "detail": "ray.rllib.evaluation",
+        "documentation": {}
+    },
+    {
+        "label": "PolicyID",
+        "importPath": "ray.rllib.utils.typing",
+        "description": "ray.rllib.utils.typing",
+        "isExtraImport": true,
+        "detail": "ray.rllib.utils.typing",
+        "documentation": {}
+    },
+    {
+        "label": "EnvActionType",
+        "importPath": "ray.rllib.utils.typing",
+        "description": "ray.rllib.utils.typing",
+        "isExtraImport": true,
+        "detail": "ray.rllib.utils.typing",
+        "documentation": {}
+    },
+    {
+        "label": "EnvInfoDict",
+        "importPath": "ray.rllib.utils.typing",
+        "description": "ray.rllib.utils.typing",
+        "isExtraImport": true,
+        "detail": "ray.rllib.utils.typing",
+        "documentation": {}
+    },
+    {
+        "label": "EnvObsType",
+        "importPath": "ray.rllib.utils.typing",
+        "description": "ray.rllib.utils.typing",
+        "isExtraImport": true,
+        "detail": "ray.rllib.utils.typing",
+        "documentation": {}
+    },
+    {
+        "label": "register_env",
+        "importPath": "ray.tune",
+        "description": "ray.tune",
+        "isExtraImport": true,
+        "detail": "ray.tune",
+        "documentation": {}
+    },
+    {
+        "label": "WandbLoggerCallback",
+        "importPath": "ray.tune.integration.wandb",
+        "description": "ray.tune.integration.wandb",
+        "isExtraImport": true,
+        "detail": "ray.tune.integration.wandb",
+        "documentation": {}
+    },
+    {
+        "label": "Wrapper",
+        "importPath": "vmas.simulator.environment",
+        "description": "vmas.simulator.environment",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.environment",
+        "documentation": {}
+    },
+    {
+        "label": "Wrapper",
+        "importPath": "vmas.simulator.environment",
+        "description": "vmas.simulator.environment",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.environment",
+        "documentation": {}
+    },
+    {
+        "label": "Environment",
+        "importPath": "vmas.simulator.environment",
+        "description": "vmas.simulator.environment",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.environment",
+        "documentation": {}
+    },
+    {
+        "label": "Wrapper",
+        "importPath": "vmas.simulator.environment",
+        "description": "vmas.simulator.environment",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.environment",
+        "documentation": {}
+    },
+    {
+        "label": "BaseHeuristicPolicy",
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "RandomPolicy",
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "BaseHeuristicPolicy",
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "BaseHeuristicPolicy",
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "BaseHeuristicPolicy",
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "BaseHeuristicPolicy",
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "BaseHeuristicPolicy",
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "BaseHeuristicPolicy",
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "vmas.simulator.utils",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "save_video",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "save_video",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "JOINT_FORCE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "AGENT_OBS_TYPE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ALPHABET",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "DEVICE_TYPING",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "override",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "extract_nested_with_index",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "INFO_TYPE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "OBS_TYPE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "REWARD_TYPE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ANGULAR_FRICTION",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "COLLISION_FORCE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "DRAG",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "JOINT_FORCE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "LINE_MIN_DIST",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "LINEAR_FRICTION",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Observable",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "override",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TORQUE_CONSTRAINT_FORCE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "x_to_rgb_colormap",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "AGENT_INFO_TYPE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "AGENT_OBS_TYPE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "AGENT_REWARD_TYPE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "INITIAL_VIEWER_SIZE",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "VIEWER_DEFAULT_ZOOM",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "save_video",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "DEVICE_TYPING",
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "random",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "random",
+        "description": "random",
+        "detail": "random",
+        "documentation": {}
+    },
+    {
+        "label": "vmas.simulator.core",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Entity",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Entity",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Entity",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Entity",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "TorchVectorizedObject",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "math",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "math",
+        "description": "math",
+        "detail": "math",
+        "documentation": {}
+    },
+    {
+        "label": "Joint",
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "Joint",
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "Joint",
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "Joint",
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "Joint",
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "Joint",
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "Joint",
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "DiffDrive",
+        "importPath": "vmas.simulator.dynamics.diff_drive",
+        "description": "vmas.simulator.dynamics.diff_drive",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.diff_drive",
+        "documentation": {}
+    },
+    {
+        "label": "DiffDrive",
+        "importPath": "vmas.simulator.dynamics.diff_drive",
+        "description": "vmas.simulator.dynamics.diff_drive",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.diff_drive",
+        "documentation": {}
+    },
+    {
+        "label": "HolonomicWithRotation",
+        "importPath": "vmas.simulator.dynamics.holonomic_with_rot",
+        "description": "vmas.simulator.dynamics.holonomic_with_rot",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.holonomic_with_rot",
+        "documentation": {}
+    },
+    {
+        "label": "HolonomicWithRotation",
+        "importPath": "vmas.simulator.dynamics.holonomic_with_rot",
+        "description": "vmas.simulator.dynamics.holonomic_with_rot",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.holonomic_with_rot",
+        "documentation": {}
+    },
+    {
+        "label": "Drone",
+        "importPath": "vmas.simulator.dynamics.drone",
+        "description": "vmas.simulator.dynamics.drone",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.drone",
+        "documentation": {}
+    },
+    {
+        "label": "KinematicBicycle",
+        "importPath": "vmas.simulator.dynamics.kinematic_bicycle",
+        "description": "vmas.simulator.dynamics.kinematic_bicycle",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.kinematic_bicycle",
+        "documentation": {}
+    },
+    {
+        "label": "Lidar",
+        "importPath": "vmas.simulator.sensors",
+        "description": "vmas.simulator.sensors",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.sensors",
+        "documentation": {}
+    },
+    {
+        "label": "Lidar",
+        "importPath": "vmas.simulator.sensors",
+        "description": "vmas.simulator.sensors",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.sensors",
+        "documentation": {}
+    },
+    {
+        "label": "Lidar",
+        "importPath": "vmas.simulator.sensors",
+        "description": "vmas.simulator.sensors",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.sensors",
+        "documentation": {}
+    },
+    {
+        "label": "Lidar",
+        "importPath": "vmas.simulator.sensors",
+        "description": "vmas.simulator.sensors",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.sensors",
+        "documentation": {}
+    },
+    {
+        "label": "Lidar",
+        "importPath": "vmas.simulator.sensors",
+        "description": "vmas.simulator.sensors",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.sensors",
+        "documentation": {}
+    },
+    {
+        "label": "Sensor",
+        "importPath": "vmas.simulator.sensors",
+        "description": "vmas.simulator.sensors",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.sensors",
+        "documentation": {}
+    },
+    {
+        "label": "operator",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "operator",
+        "description": "operator",
+        "detail": "operator",
+        "documentation": {}
+    },
+    {
+        "label": "add",
+        "importPath": "operator",
+        "description": "operator",
+        "isExtraImport": true,
+        "detail": "operator",
+        "documentation": {}
+    },
+    {
+        "label": "reduce",
+        "importPath": "functools",
+        "description": "functools",
+        "isExtraImport": true,
+        "detail": "functools",
+        "documentation": {}
+    },
+    {
+        "label": "MultivariateNormal",
+        "importPath": "torch.distributions",
+        "description": "torch.distributions",
+        "isExtraImport": true,
+        "detail": "torch.distributions",
+        "documentation": {}
+    },
+    {
+        "label": "warnings",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "warnings",
+        "description": "warnings",
+        "detail": "warnings",
+        "documentation": {}
+    },
+    {
+        "label": "abc",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "abc",
+        "description": "abc",
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "ABC",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "ABC",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "abstractmethod",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "ABC",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "abstractmethod",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "ABC",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "abstractmethod",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "ABC",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "abstractmethod",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "ABC",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "abstractmethod",
+        "importPath": "abc",
+        "description": "abc",
+        "isExtraImport": true,
+        "detail": "abc",
+        "documentation": {}
+    },
+    {
+        "label": "Dynamics",
+        "importPath": "vmas.simulator.dynamics.common",
+        "description": "vmas.simulator.dynamics.common",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.common",
+        "documentation": {}
+    },
+    {
+        "label": "Dynamics",
+        "importPath": "vmas.simulator.dynamics.common",
+        "description": "vmas.simulator.dynamics.common",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.common",
+        "documentation": {}
+    },
+    {
+        "label": "Dynamics",
+        "importPath": "vmas.simulator.dynamics.common",
+        "description": "vmas.simulator.dynamics.common",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.common",
+        "documentation": {}
+    },
+    {
+        "label": "Dynamics",
+        "importPath": "vmas.simulator.dynamics.common",
+        "description": "vmas.simulator.dynamics.common",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.common",
+        "documentation": {}
+    },
+    {
+        "label": "Dynamics",
+        "importPath": "vmas.simulator.dynamics.common",
+        "description": "vmas.simulator.dynamics.common",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.common",
+        "documentation": {}
+    },
+    {
+        "label": "Dynamics",
+        "importPath": "vmas.simulator.dynamics.common",
+        "description": "vmas.simulator.dynamics.common",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.common",
+        "documentation": {}
+    },
+    {
+        "label": "byref",
+        "importPath": "ctypes",
+        "description": "ctypes",
+        "isExtraImport": true,
+        "detail": "ctypes",
+        "documentation": {}
+    },
+    {
+        "label": "gym",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "gym",
+        "description": "gym",
+        "detail": "gym",
+        "documentation": {}
+    },
+    {
+        "label": "spaces",
+        "importPath": "gym",
+        "description": "gym",
+        "isExtraImport": true,
+        "detail": "gym",
+        "documentation": {}
+    },
+    {
+        "label": "Environment",
+        "importPath": "vmas.simulator.environment.environment",
+        "description": "vmas.simulator.environment.environment",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.environment.environment",
+        "documentation": {}
+    },
+    {
+        "label": "Environment",
+        "importPath": "vmas.simulator.environment.environment",
+        "description": "vmas.simulator.environment.environment",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.environment.environment",
+        "documentation": {}
+    },
+    {
+        "label": "annotations",
+        "importPath": "__future__",
+        "description": "__future__",
+        "isExtraImport": true,
+        "detail": "__future__",
+        "documentation": {}
+    },
+    {
+        "label": "annotations",
+        "importPath": "__future__",
+        "description": "__future__",
+        "isExtraImport": true,
+        "detail": "__future__",
+        "documentation": {}
+    },
+    {
+        "label": "annotations",
+        "importPath": "__future__",
+        "description": "__future__",
+        "isExtraImport": true,
+        "detail": "__future__",
+        "documentation": {}
+    },
+    {
+        "label": "division",
+        "importPath": "__future__",
+        "description": "__future__",
+        "isExtraImport": true,
+        "detail": "__future__",
+        "documentation": {}
+    },
+    {
+        "label": "annotations",
+        "importPath": "__future__",
+        "description": "__future__",
+        "isExtraImport": true,
+        "detail": "__future__",
+        "documentation": {}
+    },
+    {
+        "label": "Holonomic",
+        "importPath": "vmas.simulator.dynamics.holonomic",
+        "description": "vmas.simulator.dynamics.holonomic",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.dynamics.holonomic",
+        "documentation": {}
+    },
+    {
+        "label": "_get_closest_box_box",
+        "importPath": "vmas.simulator.physics",
+        "description": "vmas.simulator.physics",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.physics",
+        "documentation": {}
+    },
+    {
+        "label": "_get_closest_line_box",
+        "importPath": "vmas.simulator.physics",
+        "description": "vmas.simulator.physics",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.physics",
+        "documentation": {}
+    },
+    {
+        "label": "_get_closest_point_box",
+        "importPath": "vmas.simulator.physics",
+        "description": "vmas.simulator.physics",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.physics",
+        "documentation": {}
+    },
+    {
+        "label": "_get_closest_point_line",
+        "importPath": "vmas.simulator.physics",
+        "description": "vmas.simulator.physics",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.physics",
+        "documentation": {}
+    },
+    {
+        "label": "_get_closest_point_line_vec",
+        "importPath": "vmas.simulator.physics",
+        "description": "vmas.simulator.physics",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.physics",
+        "documentation": {}
+    },
+    {
+        "label": "_get_closest_points_line_line",
+        "importPath": "vmas.simulator.physics",
+        "description": "vmas.simulator.physics",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.physics",
+        "documentation": {}
+    },
+    {
+        "label": "_get_inner_point_box",
+        "importPath": "vmas.simulator.physics",
+        "description": "vmas.simulator.physics",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.physics",
+        "documentation": {}
+    },
+    {
+        "label": "chain",
+        "importPath": "itertools",
+        "description": "itertools",
+        "isExtraImport": true,
+        "detail": "itertools",
+        "documentation": {}
+    },
+    {
+        "label": "pyglet",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "pyglet",
+        "description": "pyglet",
+        "detail": "pyglet",
+        "documentation": {}
+    },
+    {
+        "label": "six",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "six",
+        "description": "six",
+        "detail": "six",
+        "documentation": {}
+    },
+    {
+        "label": "importlib",
+        "kind": 6,
+        "isExtraImport": true,
+        "importPath": "importlib",
+        "description": "importlib",
+        "detail": "importlib",
+        "documentation": {}
+    },
+    {
+        "label": "Enum",
+        "importPath": "enum",
+        "description": "enum",
+        "isExtraImport": true,
+        "detail": "enum",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "importPath": "vmas.make_env",
+        "description": "vmas.make_env",
+        "isExtraImport": true,
+        "detail": "vmas.make_env",
+        "documentation": {}
+    },
+    {
+        "label": "GymWrapper",
+        "importPath": "vmas.simulator.environment.gym",
+        "description": "vmas.simulator.environment.gym",
+        "isExtraImport": true,
+        "detail": "vmas.simulator.environment.gym",
+        "documentation": {}
+    },
+    {
+        "label": "find_packages",
+        "importPath": "setuptools",
+        "description": "setuptools",
+        "isExtraImport": true,
+        "detail": "setuptools",
+        "documentation": {}
+    },
+    {
+        "label": "setup",
+        "importPath": "setuptools",
+        "description": "setuptools",
+        "isExtraImport": true,
+        "detail": "setuptools",
+        "documentation": {}
+    },
+    {
+        "label": "setup",
+        "kind": 2,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "def setup(app):\n    def rst_jinja_render(app, _, source):\n        rst_context = {\"vmas\": vmas}\n        source[0] = app.builder.templates.render_string(source[0], rst_context)\n    app.connect(\"source-read\", rst_jinja_render)\n    app.add_js_file(\"js/version_alert.js\")",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "project",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "project = \"VMAS\"\ncopyright = \"ProrokLab\"\nauthor = \"Matteo Bettini\"\nversion = vmas.__version__\n# -- General configuration\nsys.path.append(osp.join(osp.dirname(benchmarl_sphinx_theme.__file__), \"extension\"))\nextensions = [\n    \"sphinx.ext.duration\",\n    \"sphinx.ext.doctest\",\n    \"sphinx.ext.autodoc\",",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "copyright",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "copyright = \"ProrokLab\"\nauthor = \"Matteo Bettini\"\nversion = vmas.__version__\n# -- General configuration\nsys.path.append(osp.join(osp.dirname(benchmarl_sphinx_theme.__file__), \"extension\"))\nextensions = [\n    \"sphinx.ext.duration\",\n    \"sphinx.ext.doctest\",\n    \"sphinx.ext.autodoc\",\n    \"sphinx.ext.autosummary\",",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "author",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "author = \"Matteo Bettini\"\nversion = vmas.__version__\n# -- General configuration\nsys.path.append(osp.join(osp.dirname(benchmarl_sphinx_theme.__file__), \"extension\"))\nextensions = [\n    \"sphinx.ext.duration\",\n    \"sphinx.ext.doctest\",\n    \"sphinx.ext.autodoc\",\n    \"sphinx.ext.autosummary\",\n    \"sphinx.ext.napoleon\",",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "version",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "version = vmas.__version__\n# -- General configuration\nsys.path.append(osp.join(osp.dirname(benchmarl_sphinx_theme.__file__), \"extension\"))\nextensions = [\n    \"sphinx.ext.duration\",\n    \"sphinx.ext.doctest\",\n    \"sphinx.ext.autodoc\",\n    \"sphinx.ext.autosummary\",\n    \"sphinx.ext.napoleon\",\n    \"sphinx.ext.intersphinx\",",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "extensions",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "extensions = [\n    \"sphinx.ext.duration\",\n    \"sphinx.ext.doctest\",\n    \"sphinx.ext.autodoc\",\n    \"sphinx.ext.autosummary\",\n    \"sphinx.ext.napoleon\",\n    \"sphinx.ext.intersphinx\",\n    \"sphinx.ext.viewcode\",\n    \"patch\",\n]",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "add_module_names",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "add_module_names = False\nautodoc_member_order = \"bysource\"\ntoc_object_entries = False\nintersphinx_mapping = {\n    \"python\": (\"https://docs.python.org/3/\", None),\n    \"sphinx\": (\"https://www.sphinx-doc.org/en/master/\", None),\n    \"torch\": (\"https://pytorch.org/docs/master\", None),\n    \"torchrl\": (\"https://pytorch.org/rl/stable/\", None),\n    \"tensordict\": (\"https://pytorch.org/tensordict/stable\", None),\n    \"benchmarl\": (\"https://benchmarl.readthedocs.io/en/latest/\", None),",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "autodoc_member_order",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "autodoc_member_order = \"bysource\"\ntoc_object_entries = False\nintersphinx_mapping = {\n    \"python\": (\"https://docs.python.org/3/\", None),\n    \"sphinx\": (\"https://www.sphinx-doc.org/en/master/\", None),\n    \"torch\": (\"https://pytorch.org/docs/master\", None),\n    \"torchrl\": (\"https://pytorch.org/rl/stable/\", None),\n    \"tensordict\": (\"https://pytorch.org/tensordict/stable\", None),\n    \"benchmarl\": (\"https://benchmarl.readthedocs.io/en/latest/\", None),\n}",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "toc_object_entries",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "toc_object_entries = False\nintersphinx_mapping = {\n    \"python\": (\"https://docs.python.org/3/\", None),\n    \"sphinx\": (\"https://www.sphinx-doc.org/en/master/\", None),\n    \"torch\": (\"https://pytorch.org/docs/master\", None),\n    \"torchrl\": (\"https://pytorch.org/rl/stable/\", None),\n    \"tensordict\": (\"https://pytorch.org/tensordict/stable\", None),\n    \"benchmarl\": (\"https://benchmarl.readthedocs.io/en/latest/\", None),\n}\nintersphinx_disabled_domains = [\"std\"]",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "intersphinx_mapping",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "intersphinx_mapping = {\n    \"python\": (\"https://docs.python.org/3/\", None),\n    \"sphinx\": (\"https://www.sphinx-doc.org/en/master/\", None),\n    \"torch\": (\"https://pytorch.org/docs/master\", None),\n    \"torchrl\": (\"https://pytorch.org/rl/stable/\", None),\n    \"tensordict\": (\"https://pytorch.org/tensordict/stable\", None),\n    \"benchmarl\": (\"https://benchmarl.readthedocs.io/en/latest/\", None),\n}\nintersphinx_disabled_domains = [\"std\"]\ntemplates_path = [\"_templates\"]",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "intersphinx_disabled_domains",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "intersphinx_disabled_domains = [\"std\"]\ntemplates_path = [\"_templates\"]\nhtml_static_path = [\n    osp.join(osp.dirname(benchmarl_sphinx_theme.__file__), \"static\"),\n    \"_static\",\n]\nhtml_theme = \"sphinx_rtd_theme\"\n# html_logo = (\n#     \"https://raw.githubusercontent.com/matteobettini/benchmarl_sphinx_theme/master/benchmarl\"\n#     \"_sphinx_theme/static/img/benchmarl_logo.png\"",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "templates_path",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "templates_path = [\"_templates\"]\nhtml_static_path = [\n    osp.join(osp.dirname(benchmarl_sphinx_theme.__file__), \"static\"),\n    \"_static\",\n]\nhtml_theme = \"sphinx_rtd_theme\"\n# html_logo = (\n#     \"https://raw.githubusercontent.com/matteobettini/benchmarl_sphinx_theme/master/benchmarl\"\n#     \"_sphinx_theme/static/img/benchmarl_logo.png\"\n# )",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "html_static_path",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "html_static_path = [\n    osp.join(osp.dirname(benchmarl_sphinx_theme.__file__), \"static\"),\n    \"_static\",\n]\nhtml_theme = \"sphinx_rtd_theme\"\n# html_logo = (\n#     \"https://raw.githubusercontent.com/matteobettini/benchmarl_sphinx_theme/master/benchmarl\"\n#     \"_sphinx_theme/static/img/benchmarl_logo.png\"\n# )\nhtml_theme_options = {\"logo_only\": False, \"navigation_depth\": 2}",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "html_theme",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "html_theme = \"sphinx_rtd_theme\"\n# html_logo = (\n#     \"https://raw.githubusercontent.com/matteobettini/benchmarl_sphinx_theme/master/benchmarl\"\n#     \"_sphinx_theme/static/img/benchmarl_logo.png\"\n# )\nhtml_theme_options = {\"logo_only\": False, \"navigation_depth\": 2}\n# html_favicon = ('')\nhtml_css_files = [\n    \"css/mytheme.css\",\n]",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "html_theme_options",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "html_theme_options = {\"logo_only\": False, \"navigation_depth\": 2}\n# html_favicon = ('')\nhtml_css_files = [\n    \"css/mytheme.css\",\n]\n# -- Options for EPUB output\nepub_show_urls = \"footnote\"\ndef setup(app):\n    def rst_jinja_render(app, _, source):\n        rst_context = {\"vmas\": vmas}",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "html_css_files",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "html_css_files = [\n    \"css/mytheme.css\",\n]\n# -- Options for EPUB output\nepub_show_urls = \"footnote\"\ndef setup(app):\n    def rst_jinja_render(app, _, source):\n        rst_context = {\"vmas\": vmas}\n        source[0] = app.builder.templates.render_string(source[0], rst_context)\n    app.connect(\"source-read\", rst_jinja_render)",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "epub_show_urls",
+        "kind": 5,
+        "importPath": "docs.source.conf",
+        "description": "docs.source.conf",
+        "peekOfCode": "epub_show_urls = \"footnote\"\ndef setup(app):\n    def rst_jinja_render(app, _, source):\n        rst_context = {\"vmas\": vmas}\n        source[0] = app.builder.templates.render_string(source[0], rst_context)\n    app.connect(\"source-read\", rst_jinja_render)\n    app.add_js_file(\"js/version_alert.js\")",
+        "detail": "docs.source.conf",
+        "documentation": {}
+    },
+    {
+        "label": "mpe_make_env",
+        "kind": 2,
+        "importPath": "mpe_comparison.mpe_performance_comparison",
+        "description": "mpe_comparison.mpe_performance_comparison",
+        "peekOfCode": "def mpe_make_env(scenario_name):\n    import mpe.multiagent.scenarios as scenarios\n    from mpe.multiagent.environment import MultiAgentEnv\n    # load scenario from script\n    scenario = scenarios.load(scenario_name + \".py\").Scenario()\n    # create world\n    world = scenario.make_world()\n    # create multiagent environment\n    env = MultiAgentEnv(\n        world, scenario.reset_world, scenario.reward, scenario.observation",
+        "detail": "mpe_comparison.mpe_performance_comparison",
+        "documentation": {}
+    },
+    {
+        "label": "run_mpe_simple_spread",
+        "kind": 2,
+        "importPath": "mpe_comparison.mpe_performance_comparison",
+        "description": "mpe_comparison.mpe_performance_comparison",
+        "peekOfCode": "def run_mpe_simple_spread(n_envs: int, n_steps: int):\n    n_envs = int(n_envs)\n    n_steps = int(n_steps)\n    n_agents = 3\n    envs = [mpe_make_env(\"simple_spread\") for _ in range(n_envs)]\n    simple_shared_action = [0, 1, 0, 0, 0]\n    [env.reset() for env in envs]\n    init_time = time.time()\n    for _ in range(n_steps):\n        for env_idx in range(n_envs):",
+        "detail": "mpe_comparison.mpe_performance_comparison",
+        "documentation": {}
+    },
+    {
+        "label": "run_vmas_simple_spread",
+        "kind": 2,
+        "importPath": "mpe_comparison.mpe_performance_comparison",
+        "description": "mpe_comparison.mpe_performance_comparison",
+        "peekOfCode": "def run_vmas_simple_spread(n_envs: int, n_steps: int, device: str):\n    n_envs = int(n_envs)\n    n_steps = int(n_steps)\n    n_agents = 3\n    env = vmas.make_env(\n        \"simple_spread\",\n        device=device,\n        num_envs=n_envs,\n        continuous_actions=False,\n        # Scenario specific config",
+        "detail": "mpe_comparison.mpe_performance_comparison",
+        "documentation": {}
+    },
+    {
+        "label": "get_device_name",
+        "kind": 2,
+        "importPath": "mpe_comparison.mpe_performance_comparison",
+        "description": "mpe_comparison.mpe_performance_comparison",
+        "peekOfCode": "def get_device_name(torch_device: str):\n    if torch_device == \"cpu\":\n        if platform.system() == \"Darwin\":\n            return \"Apple M1 Pro\"\n        else:\n            if platform.system() == \"Windows\":\n                return platform.processor()\n            elif platform.system() == \"Linux\":\n                command = \"cat /proc/cpuinfo\"\n                all_info = subprocess.check_output(command, shell=True).decode().strip()",
+        "detail": "mpe_comparison.mpe_performance_comparison",
+        "documentation": {}
+    },
+    {
+        "label": "store_pickled_evaluation",
+        "kind": 2,
+        "importPath": "mpe_comparison.mpe_performance_comparison",
+        "description": "mpe_comparison.mpe_performance_comparison",
+        "peekOfCode": "def store_pickled_evaluation(name: str, evaluation: list):\n    save_folder = (\n        f\"{os.path.dirname(os.path.realpath(__file__))}/vmas_vs_mpe_graphs/pickled\"\n    )\n    file = f\"{save_folder}/{name}.pkl\"\n    pickle.dump(evaluation, open(file, \"wb\"))\ndef load_pickled_evaluation(\n    name: str,\n):\n    save_folder = (",
+        "detail": "mpe_comparison.mpe_performance_comparison",
+        "documentation": {}
+    },
+    {
+        "label": "load_pickled_evaluation",
+        "kind": 2,
+        "importPath": "mpe_comparison.mpe_performance_comparison",
+        "description": "mpe_comparison.mpe_performance_comparison",
+        "peekOfCode": "def load_pickled_evaluation(\n    name: str,\n):\n    save_folder = (\n        f\"{os.path.dirname(os.path.realpath(__file__))}/vmas_vs_mpe_graphs/pickled\"\n    )\n    file = Path(f\"{save_folder}/{name}.pkl\")\n    if file.is_file():\n        return pickle.load(open(file, \"rb\"))\n    return None",
+        "detail": "mpe_comparison.mpe_performance_comparison",
+        "documentation": {}
+    },
+    {
+        "label": "run_comparison",
+        "kind": 2,
+        "importPath": "mpe_comparison.mpe_performance_comparison",
+        "description": "mpe_comparison.mpe_performance_comparison",
+        "peekOfCode": "def run_comparison(vmas_device: str, n_steps: int = 100):\n    device_name = get_device_name(vmas_device)\n    mpe_times = []\n    vmas_times = []\n    low = 1\n    high = 30000\n    num = 100\n    list_n_envs = np.linspace(low, high, num)\n    figure_name = f\"VMAS_vs_MPE_{n_steps}_steps_{device_name.lower().replace(' ','_')}\"\n    figure_name_pkl = figure_name + f\"_range_{low}_{high}_num_{num}\"",
+        "detail": "mpe_comparison.mpe_performance_comparison",
+        "documentation": {}
+    },
+    {
+        "label": "TestBalance",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_balance",
+        "description": "tests.test_scenarios.test_balance",
+        "peekOfCode": "class TestBalance:\n    def setup_env(\n        self,\n        n_envs,\n        **kwargs,\n    ) -> None:\n        self.n_agents = kwargs.get(\"n_agents\", 4)\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"balance\",",
+        "detail": "tests.test_scenarios.test_balance",
+        "documentation": {}
+    },
+    {
+        "label": "TestDiscovery",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_discovery",
+        "description": "tests.test_scenarios.test_discovery",
+        "peekOfCode": "class TestDiscovery:\n    def setup_env(\n        self,\n        n_envs,\n        **kwargs,\n    ) -> None:\n        self.env = make_env(\n            scenario=\"discovery\",\n            num_envs=n_envs,\n            device=\"cpu\",",
+        "detail": "tests.test_scenarios.test_discovery",
+        "documentation": {}
+    },
+    {
+        "label": "TestDispersion",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_dispersion",
+        "description": "tests.test_scenarios.test_dispersion",
+        "peekOfCode": "class TestDispersion:\n    def setup_env(\n        self, n_agents: int, share_reward: bool, penalise_by_time: bool, n_envs\n    ) -> None:\n        self.n_agents = n_agents\n        self.share_reward = share_reward\n        self.penalise_by_time = penalise_by_time\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"dispersion\",",
+        "detail": "tests.test_scenarios.test_dispersion",
+        "documentation": {}
+    },
+    {
+        "label": "TestDropout",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_dropout",
+        "description": "tests.test_scenarios.test_dropout",
+        "peekOfCode": "class TestDropout:\n    def setup_env(\n        self,\n        n_agents: int,\n        num_envs: int,\n        energy_coeff: float = DEFAULT_ENERGY_COEFF,\n    ) -> None:\n        self.n_agents = n_agents\n        self.energy_coeff = energy_coeff\n        self.continuous_actions = True",
+        "detail": "tests.test_scenarios.test_dropout",
+        "documentation": {}
+    },
+    {
+        "label": "TestFlocking",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_flocking",
+        "description": "tests.test_scenarios.test_flocking",
+        "peekOfCode": "class TestFlocking:\n    def setup_env(\n        self,\n        n_envs,\n        **kwargs,\n    ) -> None:\n        self.env = make_env(\n            scenario=\"flocking\",\n            num_envs=n_envs,\n            device=\"cpu\",",
+        "detail": "tests.test_scenarios.test_flocking",
+        "documentation": {}
+    },
+    {
+        "label": "TestFootball",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_football",
+        "description": "tests.test_scenarios.test_football",
+        "peekOfCode": "class TestFootball:\n    def setup_env(self, n_envs, **kwargs) -> None:\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"football\",\n            num_envs=n_envs,\n            device=\"cpu\",\n            continuous_actions=True,\n            # Environment specific variables\n            **kwargs,",
+        "detail": "tests.test_scenarios.test_football",
+        "documentation": {}
+    },
+    {
+        "label": "TestGiveWay",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_give_way",
+        "description": "tests.test_scenarios.test_give_way",
+        "peekOfCode": "class TestGiveWay:\n    def setup_env(self, n_envs, **kwargs) -> None:\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"give_way\",\n            num_envs=n_envs,\n            device=\"cpu\",\n            continuous_actions=self.continuous_actions,\n            # Environment specific variables\n            **kwargs,",
+        "detail": "tests.test_scenarios.test_give_way",
+        "documentation": {}
+    },
+    {
+        "label": "TestNavigation",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_navigation",
+        "description": "tests.test_scenarios.test_navigation",
+        "peekOfCode": "class TestNavigation:\n    def setUp(self, n_envs, n_agents) -> None:\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"navigation\",\n            num_envs=n_envs,\n            device=\"cpu\",\n            continuous_actions=self.continuous_actions,\n            # Environment specific variables\n            n_agents=n_agents,",
+        "detail": "tests.test_scenarios.test_navigation",
+        "documentation": {}
+    },
+    {
+        "label": "TestPassage",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_passage",
+        "description": "tests.test_scenarios.test_passage",
+        "peekOfCode": "class TestPassage:\n    def setup_env(\n        self,\n        n_envs,\n        **kwargs,\n    ) -> None:\n        self.n_passages = kwargs.get(\"n_passages\", 4)\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"passage\",",
+        "detail": "tests.test_scenarios.test_passage",
+        "documentation": {}
+    },
+    {
+        "label": "TestReverseTransport",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_reverse_transport",
+        "description": "tests.test_scenarios.test_reverse_transport",
+        "peekOfCode": "class TestReverseTransport:\n    def setup_env(self, n_envs, **kwargs) -> None:\n        self.n_agents = kwargs.get(\"n_agents\", 4)\n        self.package_width = kwargs.get(\"package_width\", 0.6)\n        self.package_length = kwargs.get(\"package_length\", 0.6)\n        self.package_mass = kwargs.get(\"package_mass\", 50)\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"reverse_transport\",\n            num_envs=n_envs,",
+        "detail": "tests.test_scenarios.test_reverse_transport",
+        "documentation": {}
+    },
+    {
+        "label": "TestTransport",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_transport",
+        "description": "tests.test_scenarios.test_transport",
+        "peekOfCode": "class TestTransport:\n    def setup_env(self, n_envs, **kwargs) -> None:\n        self.n_agents = kwargs.get(\"n_agents\", 4)\n        self.n_packages = kwargs.get(\"n_packages\", 1)\n        self.package_width = kwargs.get(\"package_width\", 0.15)\n        self.package_length = kwargs.get(\"package_length\", 0.15)\n        self.package_mass = kwargs.get(\"package_mass\", 50)\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"transport\",",
+        "detail": "tests.test_scenarios.test_transport",
+        "documentation": {}
+    },
+    {
+        "label": "TestWaterfall",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_waterfall",
+        "description": "tests.test_scenarios.test_waterfall",
+        "peekOfCode": "class TestWaterfall:\n    def setUp(self, n_envs, n_agents) -> None:\n        self.continuous_actions = True\n        self.env = make_env(\n            scenario=\"waterfall\",\n            num_envs=n_envs,\n            device=\"cpu\",\n            continuous_actions=self.continuous_actions,\n            # Environment specific variables\n            n_agents=n_agents,",
+        "detail": "tests.test_scenarios.test_waterfall",
+        "documentation": {}
+    },
+    {
+        "label": "TestWheel",
+        "kind": 6,
+        "importPath": "tests.test_scenarios.test_wheel",
+        "description": "tests.test_scenarios.test_wheel",
+        "peekOfCode": "class TestWheel:\n    def setup_env(\n        self,\n        n_envs,\n        n_agents,\n        **kwargs,\n    ) -> None:\n        self.desired_velocity = kwargs.get(\"desired_velocity\", 0.1)\n        self.continuous_actions = True\n        self.n_envs = 15",
+        "detail": "tests.test_scenarios.test_wheel",
+        "documentation": {}
+    },
+    {
+        "label": "scenario_names",
+        "kind": 2,
+        "importPath": "tests.test_vmas",
+        "description": "tests.test_vmas",
+        "peekOfCode": "def scenario_names():\n    scenarios = []\n    scenarios_folder = Path(__file__).parent.parent / \"vmas\" / \"scenarios\"\n    for _, _, filenames in os.walk(scenarios_folder):\n        scenarios += filenames\n    scenarios = [\n        scenario.split(\".\")[0]\n        for scenario in scenarios\n        if scenario.endswith(\".py\") and not scenario.startswith(\"__\")\n    ]",
+        "detail": "tests.test_vmas",
+        "documentation": {}
+    },
+    {
+        "label": "test_all_scenarios_included",
+        "kind": 2,
+        "importPath": "tests.test_vmas",
+        "description": "tests.test_vmas",
+        "peekOfCode": "def test_all_scenarios_included():\n    from vmas import debug_scenarios, mpe_scenarios, scenarios\n    assert sorted(scenario_names()) == sorted(\n        scenarios + mpe_scenarios + debug_scenarios\n    )\n@pytest.mark.parametrize(\"scenario\", scenario_names())\n@pytest.mark.parametrize(\"continuous_actions\", [True, False])\ndef test_use_vmas_env(\n    scenario, continuous_actions, dict_spaces=True, num_envs=10, n_steps=10\n):",
+        "detail": "tests.test_vmas",
+        "documentation": {}
+    },
+    {
+        "label": "test_use_vmas_env",
+        "kind": 2,
+        "importPath": "tests.test_vmas",
+        "description": "tests.test_vmas",
+        "peekOfCode": "def test_use_vmas_env(\n    scenario, continuous_actions, dict_spaces=True, num_envs=10, n_steps=10\n):\n    render = True\n    if sys.platform.startswith(\"win32\"):\n        # Windows on github servers has issues with pyglet\n        render = False\n    use_vmas_env(\n        render=render,\n        save_render=False,",
+        "detail": "tests.test_vmas",
+        "documentation": {}
+    },
+    {
+        "label": "test_multi_discrete_actions",
+        "kind": 2,
+        "importPath": "tests.test_vmas",
+        "description": "tests.test_vmas",
+        "peekOfCode": "def test_multi_discrete_actions(scenario, num_envs=10, n_steps=10):\n    env = make_env(\n        scenario=scenario,\n        num_envs=num_envs,\n        seed=0,\n        multidiscrete_actions=True,\n        continuous_actions=False,\n    )\n    for _ in range(n_steps):\n        env.step(env.get_random_actions())",
+        "detail": "tests.test_vmas",
+        "documentation": {}
+    },
+    {
+        "label": "test_non_dict_spaces_actions",
+        "kind": 2,
+        "importPath": "tests.test_vmas",
+        "description": "tests.test_vmas",
+        "peekOfCode": "def test_non_dict_spaces_actions(scenario, num_envs=10, n_steps=10):\n    env = make_env(\n        scenario=scenario,\n        num_envs=num_envs,\n        seed=0,\n        continuous_actions=True,\n        dict_spaces=False,\n    )\n    for _ in range(n_steps):\n        env.step(env.get_random_actions())",
+        "detail": "tests.test_vmas",
+        "documentation": {}
+    },
+    {
+        "label": "test_partial_reset",
+        "kind": 2,
+        "importPath": "tests.test_vmas",
+        "description": "tests.test_vmas",
+        "peekOfCode": "def test_partial_reset(scenario, num_envs=10, n_steps=10):\n    env = make_env(\n        scenario=scenario,\n        num_envs=num_envs,\n        seed=0,\n    )\n    env_index = 0\n    for _ in range(n_steps):\n        env.step(env.get_random_actions())\n        env.reset_at(env_index)",
+        "detail": "tests.test_vmas",
+        "documentation": {}
+    },
+    {
+        "label": "test_global_reset",
+        "kind": 2,
+        "importPath": "tests.test_vmas",
+        "description": "tests.test_vmas",
+        "peekOfCode": "def test_global_reset(scenario, num_envs=10, n_steps=10):\n    env = make_env(\n        scenario=scenario,\n        num_envs=num_envs,\n        seed=0,\n    )\n    for step in range(n_steps):\n        env.step(env.get_random_actions())\n        if step == n_steps // 2:\n            env.reset()",
+        "detail": "tests.test_vmas",
+        "documentation": {}
+    },
+    {
+        "label": "test_vmas_differentiable",
+        "kind": 2,
+        "importPath": "tests.test_vmas",
+        "description": "tests.test_vmas",
+        "peekOfCode": "def test_vmas_differentiable(scenario, n_steps=10, n_envs=10):\n    if scenario == \"football\" or scenario == \"simple_crypto\":\n        pytest.skip()\n    env = make_env(\n        scenario=scenario,\n        num_envs=n_envs,\n        continuous_actions=True,\n        seed=0,\n        grad_enabled=True,\n    )",
+        "detail": "tests.test_vmas",
+        "documentation": {}
+    },
+    {
+        "label": "EvaluationCallbacks",
+        "kind": 6,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "class EvaluationCallbacks(DefaultCallbacks):\n    def on_episode_step(\n        self,\n        *,\n        worker: RolloutWorker,\n        base_env: BaseEnv,\n        episode: MultiAgentEpisode,\n        **kwargs,\n    ):\n        info = episode.last_info_for()",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "RenderingCallbacks",
+        "kind": 6,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "class RenderingCallbacks(DefaultCallbacks):\n    def __init__(self, *args, **kwargs):\n        super().__init__(*args, **kwargs)\n        self.frames = []\n    def on_episode_step(\n        self,\n        *,\n        worker: RolloutWorker,\n        base_env: BaseEnv,\n        policies: Optional[Dict[PolicyID, Policy]] = None,",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "env_creator",
+        "kind": 2,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "def env_creator(config: Dict):\n    env = make_env(\n        scenario=config[\"scenario_name\"],\n        num_envs=config[\"num_envs\"],\n        device=config[\"device\"],\n        continuous_actions=config[\"continuous_actions\"],\n        wrapper=Wrapper.RLLIB,\n        max_steps=config[\"max_steps\"],\n        # Scenario specific variables\n        **config[\"scenario_config\"],",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "train",
+        "kind": 2,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "def train():\n    RLLIB_NUM_GPUS = int(os.environ.get(\"RLLIB_NUM_GPUS\", \"0\"))\n    num_gpus = 0.001 if RLLIB_NUM_GPUS > 0 else 0  # Driver GPU\n    num_gpus_per_worker = (\n        (RLLIB_NUM_GPUS - num_gpus) / (num_workers + 1) if vmas_device == \"cuda\" else 0\n    )\n    tune.run(\n        PPOTrainer,\n        stop={\"training_iteration\": 5000},\n        checkpoint_freq=1,",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "scenario_name",
+        "kind": 5,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "scenario_name = \"balance\"\n# Scenario specific variables.\n# When modifying this also modify env_config and env_creator\nn_agents = 4\n# Common variables\ncontinuous_actions = True\nmax_steps = 200\nnum_vectorized_envs = 96\nnum_workers = 5\nvmas_device = \"cpu\"  # or cuda",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "n_agents",
+        "kind": 5,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "n_agents = 4\n# Common variables\ncontinuous_actions = True\nmax_steps = 200\nnum_vectorized_envs = 96\nnum_workers = 5\nvmas_device = \"cpu\"  # or cuda\ndef env_creator(config: Dict):\n    env = make_env(\n        scenario=config[\"scenario_name\"],",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "continuous_actions",
+        "kind": 5,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "continuous_actions = True\nmax_steps = 200\nnum_vectorized_envs = 96\nnum_workers = 5\nvmas_device = \"cpu\"  # or cuda\ndef env_creator(config: Dict):\n    env = make_env(\n        scenario=config[\"scenario_name\"],\n        num_envs=config[\"num_envs\"],\n        device=config[\"device\"],",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "max_steps",
+        "kind": 5,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "max_steps = 200\nnum_vectorized_envs = 96\nnum_workers = 5\nvmas_device = \"cpu\"  # or cuda\ndef env_creator(config: Dict):\n    env = make_env(\n        scenario=config[\"scenario_name\"],\n        num_envs=config[\"num_envs\"],\n        device=config[\"device\"],\n        continuous_actions=config[\"continuous_actions\"],",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "num_vectorized_envs",
+        "kind": 5,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "num_vectorized_envs = 96\nnum_workers = 5\nvmas_device = \"cpu\"  # or cuda\ndef env_creator(config: Dict):\n    env = make_env(\n        scenario=config[\"scenario_name\"],\n        num_envs=config[\"num_envs\"],\n        device=config[\"device\"],\n        continuous_actions=config[\"continuous_actions\"],\n        wrapper=Wrapper.RLLIB,",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "num_workers",
+        "kind": 5,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "num_workers = 5\nvmas_device = \"cpu\"  # or cuda\ndef env_creator(config: Dict):\n    env = make_env(\n        scenario=config[\"scenario_name\"],\n        num_envs=config[\"num_envs\"],\n        device=config[\"device\"],\n        continuous_actions=config[\"continuous_actions\"],\n        wrapper=Wrapper.RLLIB,\n        max_steps=config[\"max_steps\"],",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "vmas_device",
+        "kind": 5,
+        "importPath": "vmas.examples.rllib",
+        "description": "vmas.examples.rllib",
+        "peekOfCode": "vmas_device = \"cpu\"  # or cuda\ndef env_creator(config: Dict):\n    env = make_env(\n        scenario=config[\"scenario_name\"],\n        num_envs=config[\"num_envs\"],\n        device=config[\"device\"],\n        continuous_actions=config[\"continuous_actions\"],\n        wrapper=Wrapper.RLLIB,\n        max_steps=config[\"max_steps\"],\n        # Scenario specific variables",
+        "detail": "vmas.examples.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "run_heuristic",
+        "kind": 2,
+        "importPath": "vmas.examples.run_heuristic",
+        "description": "vmas.examples.run_heuristic",
+        "peekOfCode": "def run_heuristic(\n    scenario_name: str,\n    heuristic: Type[BaseHeuristicPolicy] = RandomPolicy,\n    n_steps: int = 200,\n    n_envs: int = 32,\n    env_kwargs: dict = None,\n    render: bool = False,\n    save_render: bool = False,\n    device: str = \"cpu\",\n):",
+        "detail": "vmas.examples.run_heuristic",
+        "documentation": {}
+    },
+    {
+        "label": "use_vmas_env",
+        "kind": 2,
+        "importPath": "vmas.examples.use_vmas_env",
+        "description": "vmas.examples.use_vmas_env",
+        "peekOfCode": "def use_vmas_env(\n    render: bool = False,\n    save_render: bool = False,\n    num_envs: int = 32,\n    n_steps: int = 100,\n    random_action: bool = False,\n    device: str = \"cpu\",\n    scenario_name: str = \"waterfall\",\n    continuous_actions: bool = True,\n    visualize_render: bool = True,",
+        "detail": "vmas.examples.use_vmas_env",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.asym_joint",
+        "description": "vmas.scenarios.debug.asym_joint",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.joint_length = kwargs.pop(\"joint_length\", 0.5)\n        self.random_start_angle = kwargs.pop(\"random_start_angle\", False)\n        self.observe_joint_angle = kwargs.pop(\"observe_joint_angle\", False)\n        self.joint_angle_obs_noise = kwargs.pop(\"joint_angle_obs_noise\", 0.0)\n        self.asym_package = kwargs.pop(\"asym_package\", True)\n        self.mass_ratio = kwargs.pop(\"mass_ratio\", 5)\n        self.mass_position = kwargs.pop(\"mass_position\", 0.75)\n        self.max_speed_1 = kwargs.pop(\"max_speed_1\", None)  # 0.1",
+        "detail": "vmas.scenarios.debug.asym_joint",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_0_90",
+        "kind": 2,
+        "importPath": "vmas.scenarios.debug.asym_joint",
+        "description": "vmas.scenarios.debug.asym_joint",
+        "peekOfCode": "def get_line_angle_0_90(rot: Tensor):\n    angle = torch.abs(rot) % torch.pi\n    other_angle = torch.pi - angle\n    return torch.minimum(angle, other_angle)\ndef get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)",
+        "detail": "vmas.scenarios.debug.asym_joint",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_0_180",
+        "kind": 2,
+        "importPath": "vmas.scenarios.debug.asym_joint",
+        "description": "vmas.scenarios.debug.asym_joint",
+        "peekOfCode": "def get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)\n    return torch.minimum(\n        (angle - goal).abs(),\n        torch.minimum(\n            (angle - (goal - torch.pi)).abs(),",
+        "detail": "vmas.scenarios.debug.asym_joint",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_dist_0_180",
+        "kind": 2,
+        "importPath": "vmas.scenarios.debug.asym_joint",
+        "description": "vmas.scenarios.debug.asym_joint",
+        "peekOfCode": "def get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)\n    return torch.minimum(\n        (angle - goal).abs(),\n        torch.minimum(\n            (angle - (goal - torch.pi)).abs(),\n            ((angle - torch.pi) - goal).abs(),\n        ),\n    ).squeeze(-1)",
+        "detail": "vmas.scenarios.debug.asym_joint",
+        "documentation": {}
+    },
+    {
+        "label": "angle_to_vector",
+        "kind": 2,
+        "importPath": "vmas.scenarios.debug.asym_joint",
+        "description": "vmas.scenarios.debug.asym_joint",
+        "peekOfCode": "def angle_to_vector(angle):\n    return torch.cat([torch.cos(angle), torch.sin(angle)], dim=1)\nclass Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.joint_length = kwargs.pop(\"joint_length\", 0.5)\n        self.random_start_angle = kwargs.pop(\"random_start_angle\", False)\n        self.observe_joint_angle = kwargs.pop(\"observe_joint_angle\", False)\n        self.joint_angle_obs_noise = kwargs.pop(\"joint_angle_obs_noise\", 0.0)\n        self.asym_package = kwargs.pop(\"asym_package\", True)\n        self.mass_ratio = kwargs.pop(\"mass_ratio\", 5)",
+        "detail": "vmas.scenarios.debug.asym_joint",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.circle_trajectory",
+        "description": "vmas.scenarios.debug.circle_trajectory",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.u_range = kwargs.pop(\"u_range\", 1)\n        self.a_range = kwargs.pop(\"a_range\", 1)\n        self.obs_noise = kwargs.pop(\"obs_noise\", 0.0)\n        self.dt_delay = kwargs.pop(\"dt_delay\", 0)\n        self.min_input_norm = kwargs.pop(\"min_input_norm\", 0.08)\n        self.linear_friction = kwargs.pop(\"linear_friction\", 0.1)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.agent_radius = 0.16",
+        "detail": "vmas.scenarios.debug.circle_trajectory",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.diff_drive",
+        "description": "vmas.scenarios.debug.diff_drive",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        \"\"\"\n        Differential drive example scenario\n        Run this file to try it out\n        The first agent has differential drive dynamics.\n        You can control its forward input with the LEFT and RIGHT arrows.\n        You can control its rotation with UP and DOWN.\n        The second agent has standard vmas holonomic dynamics.\n        You can control it with WASD",
+        "detail": "vmas.scenarios.debug.diff_drive",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.drone",
+        "description": "vmas.scenarios.debug.drone",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        \"\"\"\n        Drone example scenario\n        Run this file to try it out.\n        You can control the three input torques using left/right arrows, up/down arrows, and m/n.\n        \"\"\"\n        self.plot_grid = True\n        self.n_agents = kwargs.pop(\"n_agents\", 2)\n        ScenarioUtils.check_kwargs_consumed(kwargs)",
+        "detail": "vmas.scenarios.debug.drone",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.goal",
+        "description": "vmas.scenarios.debug.goal",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.u_range = kwargs.pop(\"u_range\", 1)\n        self.a_range = kwargs.pop(\"a_range\", 1)\n        self.obs_noise = kwargs.pop(\"obs_noise\", 0.0)\n        self.dt_delay = kwargs.pop(\"dt_delay\", 0)\n        self.min_input_norm = kwargs.pop(\"min_input_norm\", 0.08)\n        self.linear_friction = kwargs.pop(\"linear_friction\", 0.1)\n        self.pos_shaping_factor = kwargs.pop(\"pos_shaping_factor\", 1.0)\n        self.time_rew_coeff = kwargs.pop(\"time_rew_coeff\", -0.01)",
+        "detail": "vmas.scenarios.debug.goal",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.het_mass",
+        "description": "vmas.scenarios.debug.het_mass",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.green_mass = kwargs.pop(\"green_mass\", 4)\n        self.blue_mass = kwargs.pop(\"blue_mass\", 2)\n        self.mass_noise = kwargs.pop(\"mass_noise\", 1)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.plot_grid = True\n        # Make world\n        world = World(batch_dim, device)\n        # Add agents",
+        "detail": "vmas.scenarios.debug.het_mass",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.kinematic_bicycle",
+        "description": "vmas.scenarios.debug.kinematic_bicycle",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        \"\"\"\n        Kinematic bicycle model example scenario\n        \"\"\"\n        self.n_agents = kwargs.pop(\"n_agents\", 2)\n        width = kwargs.pop(\"width\", 0.1)  # Agent width\n        l_f = kwargs.pop(\n            \"l_f\", 0.1\n        )  # Distance between the front axle and the center of gravity",
+        "detail": "vmas.scenarios.debug.kinematic_bicycle",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.lidar_test",
+        "description": "vmas.scenarios.debug.lidar_test",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        \"\"\"\n        Differential drive example scenario\n        Run this file to try it out\n        The first agent has differential drive dynamics.\n        You can control its forward input with the LEFT and RIGHT arrows.\n        You can control its rotation with UP and DOWN.\n        The second agent has standard vmas holonomic dynamics.\n        You can control it with WASD",
+        "detail": "vmas.scenarios.debug.lidar_test",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.line_trajectory",
+        "description": "vmas.scenarios.debug.line_trajectory",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.obs_noise = kwargs.pop(\"obs_noise\", 0)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.agent_radius = 0.03\n        self.line_length = 3\n        # Make world\n        world = World(batch_dim, device, drag=0.1)\n        # Add agents\n        self.agent = Agent(",
+        "detail": "vmas.scenarios.debug.line_trajectory",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.pollock",
+        "description": "vmas.scenarios.debug.pollock",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_agents = kwargs.pop(\"n_agents\", 15)\n        self.n_lines = kwargs.pop(\"n_lines\", 15)\n        self.n_boxes = kwargs.pop(\"n_boxes\", 15)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.agent_radius = 0.05\n        self.line_length = 0.3\n        self.box_length = 0.2\n        self.box_width = 0.1",
+        "detail": "vmas.scenarios.debug.pollock",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.vel_control",
+        "description": "vmas.scenarios.debug.vel_control",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.green_mass = kwargs.pop(\"green_mass\", 1)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.plot_grid = True\n        self.agent_radius = 0.16\n        controller_params = [2, 6, 0.002]\n        linear_friction = 0.1\n        v_range = 1\n        a_range = 1",
+        "detail": "vmas.scenarios.debug.vel_control",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.debug.waterfall",
+        "description": "vmas.scenarios.debug.waterfall",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_agents = kwargs.pop(\"n_agents\", 5)\n        self.with_joints = kwargs.pop(\"joints\", True)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.agent_dist = 0.1\n        self.agent_radius = 0.04\n        # Make world\n        world = World(\n            batch_dim,",
+        "detail": "vmas.scenarios.debug.waterfall",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple",
+        "description": "vmas.scenarios.mpe.simple",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        # Make world\n        world = World(batch_dim, device)\n        # Add agents\n        for i in range(1):\n            agent = Agent(name=f\"agent_{i}\", collide=False, color=Color.GRAY)\n            world.add_agent(agent)\n        # Add landmarks",
+        "detail": "vmas.scenarios.mpe.simple",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple_adversary",
+        "description": "vmas.scenarios.mpe.simple_adversary",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        n_agents = kwargs.pop(\"n_agents\", 3)\n        n_adversaries = kwargs.pop(\"n_adversaries\", 1)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        assert n_agents > n_adversaries\n        world = World(\n            batch_dim=batch_dim,\n            device=device,\n        )",
+        "detail": "vmas.scenarios.mpe.simple_adversary",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple_crypto",
+        "description": "vmas.scenarios.mpe.simple_crypto",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        dim_c = kwargs.pop(\"dim_c\", 4)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        assert dim_c > 0\n        world = World(\n            batch_dim=batch_dim,\n            device=device,\n            dim_c=dim_c,\n        )",
+        "detail": "vmas.scenarios.mpe.simple_crypto",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple_push",
+        "description": "vmas.scenarios.mpe.simple_push",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        world = World(\n            batch_dim=batch_dim,\n            device=device,\n        )\n        num_agents = 2\n        num_adversaries = 1\n        num_landmarks = 2",
+        "detail": "vmas.scenarios.mpe.simple_push",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple_reference",
+        "description": "vmas.scenarios.mpe.simple_reference",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        world = World(batch_dim=batch_dim, device=device, dim_c=10)\n        n_agents = 2\n        n_landmarks = 3\n        # Add agents\n        for i in range(n_agents):\n            agent = Agent(name=f\"agent_{i}\", collide=False, silent=False)\n            world.add_agent(agent)",
+        "detail": "vmas.scenarios.mpe.simple_reference",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple_speaker_listener",
+        "description": "vmas.scenarios.mpe.simple_speaker_listener",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        world = World(batch_dim=batch_dim, device=device, dim_c=3)\n        # set any world properties first\n        num_agents = 2\n        num_landmarks = 3\n        # Add agents\n        for i in range(num_agents):\n            speaker = True if i == 0 else False",
+        "detail": "vmas.scenarios.mpe.simple_speaker_listener",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple_spread",
+        "description": "vmas.scenarios.mpe.simple_spread",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        num_agents = kwargs.pop(\"n_agents\", 3)\n        obs_agents = kwargs.pop(\"obs_agents\", True)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.obs_agents = obs_agents\n        world = World(batch_dim=batch_dim, device=device)\n        # set any world properties first\n        num_landmarks = num_agents\n        # Add agents",
+        "detail": "vmas.scenarios.mpe.simple_spread",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple_tag",
+        "description": "vmas.scenarios.mpe.simple_tag",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        num_good_agents = kwargs.pop(\"num_good_agents\", 1)\n        num_adversaries = kwargs.pop(\"num_adversaries\", 3)\n        num_landmarks = kwargs.pop(\"num_landmarks\", 2)\n        self.shape_agent_rew = kwargs.pop(\"shape_agent_rew\", False)\n        self.shape_adversary_rew = kwargs.pop(\"shape_adversary_rew\", False)\n        self.agents_share_rew = kwargs.pop(\"agents_share_rew\", False)\n        self.adversaries_share_rew = kwargs.pop(\"adversaries_share_rew\", True)\n        self.observe_same_team = kwargs.pop(\"observe_same_team\", True)",
+        "detail": "vmas.scenarios.mpe.simple_tag",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.mpe.simple_world_comm",
+        "description": "vmas.scenarios.mpe.simple_world_comm",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        world = World(\n            batch_dim=batch_dim,\n            device=device,\n            x_semidim=1,\n            y_semidim=1,\n            dim_c=4,\n        )\n        num_good_agents = kwargs.pop(\"num_good_agents\", 2)",
+        "detail": "vmas.scenarios.mpe.simple_world_comm",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.balance",
+        "description": "vmas.scenarios.balance",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_agents = kwargs.pop(\"n_agents\", 3)\n        self.package_mass = kwargs.pop(\"package_mass\", 5)\n        self.random_package_pos_on_line = kwargs.pop(\"random_package_pos_on_line\", True)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        assert self.n_agents > 1\n        self.line_length = 0.8\n        self.agent_radius = 0.03\n        self.shaping_factor = 100",
+        "detail": "vmas.scenarios.balance",
+        "documentation": {}
+    },
+    {
+        "label": "HeuristicPolicy",
+        "kind": 6,
+        "importPath": "vmas.scenarios.balance",
+        "description": "vmas.scenarios.balance",
+        "peekOfCode": "class HeuristicPolicy(BaseHeuristicPolicy):\n    def compute_action(self, observation: torch.Tensor, u_range: float) -> torch.Tensor:\n        batch_dim = observation.shape[0]\n        index_package_goal_pos = 8\n        dist_package_goal = observation[\n            :, index_package_goal_pos : index_package_goal_pos + 2\n        ]\n        y_distance_ge_0 = dist_package_goal[:, Y] >= 0\n        if self.continuous_actions:\n            action_agent = torch.clamp(",
+        "detail": "vmas.scenarios.balance",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.ball_passage",
+        "description": "vmas.scenarios.ball_passage",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_passages = kwargs.pop(\"n_passages\", 1)\n        self.fixed_passage = kwargs.pop(\"fixed_passage\", False)\n        self.random_start_angle = kwargs.pop(\"random_start_angle\", True)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        assert 1 <= self.n_passages <= 20\n        self.pos_shaping_factor = 1\n        self.collision_reward = -0.06\n        self.n_agents = 2",
+        "detail": "vmas.scenarios.ball_passage",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.ball_trajectory",
+        "description": "vmas.scenarios.ball_trajectory",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.pos_shaping_factor = kwargs.pop(\"pos_shaping_factor\", 0)\n        self.speed_shaping_factor = kwargs.pop(\"speed_shaping_factor\", 1)\n        self.dist_shaping_factor = kwargs.pop(\"dist_shaping_factor\", 0)\n        self.joints = kwargs.pop(\"joints\", True)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.n_agents = 2\n        self.desired_speed = 1\n        self.desired_radius = 0.5",
+        "detail": "vmas.scenarios.ball_trajectory",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.buzz_wire",
+        "description": "vmas.scenarios.buzz_wire",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.random_start_angle = kwargs.pop(\"random_start_angle\", True)\n        self.pos_shaping_factor = kwargs.pop(\"pos_shaping_factor\", 1)\n        self.collision_reward = kwargs.pop(\"collision_reward\", -10)\n        self.max_speed_1 = kwargs.pop(\"max_speed_1\", None)  # 0.05\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.pos_shaping_factor = 1\n        self.n_agents = 2\n        self.wall_length = 2",
+        "detail": "vmas.scenarios.buzz_wire",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.discovery",
+        "description": "vmas.scenarios.discovery",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_agents = kwargs.pop(\"n_agents\", 5)\n        self.n_targets = kwargs.pop(\"n_targets\", 7)\n        self._min_dist_between_entities = kwargs.pop(\"min_dist_between_entities\", 0.2)\n        self._lidar_range = kwargs.pop(\"lidar_range\", 0.35)\n        self._covering_range = kwargs.pop(\"covering_range\", 0.25)\n        self._agents_per_target = kwargs.pop(\"agents_per_target\", 2)\n        self.targets_respawn = kwargs.pop(\"targets_respawn\", True)\n        self.shared_reward = kwargs.pop(\"shared_reward\", False)",
+        "detail": "vmas.scenarios.discovery",
+        "documentation": {}
+    },
+    {
+        "label": "HeuristicPolicy",
+        "kind": 6,
+        "importPath": "vmas.scenarios.discovery",
+        "description": "vmas.scenarios.discovery",
+        "peekOfCode": "class HeuristicPolicy(BaseHeuristicPolicy):\n    def compute_action(self, observation: torch.Tensor, u_range: float) -> torch.Tensor:\n        assert self.continuous_actions\n        # First calculate the closest point to a circle of radius circle_radius given the current position\n        circle_origin = torch.zeros(1, 2, device=observation.device)\n        circle_radius = 0.75\n        current_pos = observation[:, :2]\n        v = current_pos - circle_origin\n        closest_point_on_circ = (\n            circle_origin + v / torch.linalg.norm(v, dim=1).unsqueeze(1) * circle_radius",
+        "detail": "vmas.scenarios.discovery",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.dispersion",
+        "description": "vmas.scenarios.dispersion",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        n_agents = kwargs.pop(\"n_agents\", 4)\n        self.share_reward = kwargs.pop(\"share_reward\", False)\n        self.penalise_by_time = kwargs.pop(\"penalise_by_time\", False)\n        self.food_radius = kwargs.pop(\"food_radius\", 0.05)\n        self.pos_range = kwargs.pop(\"pos_range\", 1.0)\n        n_food = kwargs.pop(\"n_food\", n_agents)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        # Make world",
+        "detail": "vmas.scenarios.dispersion",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.dropout",
+        "description": "vmas.scenarios.dropout",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        n_agents = kwargs.pop(\"n_agents\", 4)\n        self.energy_coeff = kwargs.pop(\n            \"energy_coeff\", DEFAULT_ENERGY_COEFF\n        )  # Weight of team energy penalty\n        self.start_same_point = kwargs.pop(\"start_same_point\", False)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.agent_radius = 0.05\n        self.goal_radius = 0.03",
+        "detail": "vmas.scenarios.dropout",
+        "documentation": {}
+    },
+    {
+        "label": "DEFAULT_ENERGY_COEFF",
+        "kind": 5,
+        "importPath": "vmas.scenarios.dropout",
+        "description": "vmas.scenarios.dropout",
+        "peekOfCode": "DEFAULT_ENERGY_COEFF = 0.02\nclass Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        n_agents = kwargs.pop(\"n_agents\", 4)\n        self.energy_coeff = kwargs.pop(\n            \"energy_coeff\", DEFAULT_ENERGY_COEFF\n        )  # Weight of team energy penalty\n        self.start_same_point = kwargs.pop(\"start_same_point\", False)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.agent_radius = 0.05",
+        "detail": "vmas.scenarios.dropout",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.flocking",
+        "description": "vmas.scenarios.flocking",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        n_agents = kwargs.pop(\"n_agents\", 4)\n        n_obstacles = kwargs.pop(\"n_obstacles\", 5)\n        self._min_dist_between_entities = kwargs.pop(\"min_dist_between_entities\", 0.15)\n        self.collision_reward = kwargs.pop(\"collision_reward\", -0.1)\n        self.dist_shaping_factor = kwargs.pop(\"dist_shaping_factor\", 1)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.plot_grid = True\n        self.desired_distance = 0.1",
+        "detail": "vmas.scenarios.flocking",
+        "documentation": {}
+    },
+    {
+        "label": "HeuristicPolicy",
+        "kind": 6,
+        "importPath": "vmas.scenarios.flocking",
+        "description": "vmas.scenarios.flocking",
+        "peekOfCode": "class HeuristicPolicy(BaseHeuristicPolicy):\n    def compute_action(self, observation: torch.Tensor, u_range: float) -> torch.Tensor:\n        assert self.continuous_actions\n        # First calculate the closest point to a circle of radius circle_radius given the current position\n        circle_origin = torch.zeros(1, 2)\n        circle_radius = 0.3\n        current_pos = observation[:, :2]\n        v = current_pos - circle_origin\n        closest_point_on_circ = (\n            circle_origin + v / torch.linalg.norm(v, dim=1).unsqueeze(1) * circle_radius",
+        "detail": "vmas.scenarios.flocking",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.football",
+        "description": "vmas.scenarios.football",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.init_params(**kwargs)\n        world = self.init_world(batch_dim, device)\n        self.init_agents(world)\n        self.init_ball(world)\n        self.init_background(world)\n        self.init_walls(world)\n        self.init_goals(world)\n        # self.init_traj_pts(world)",
+        "detail": "vmas.scenarios.football",
+        "documentation": {}
+    },
+    {
+        "label": "AgentPolicy",
+        "kind": 6,
+        "importPath": "vmas.scenarios.football",
+        "description": "vmas.scenarios.football",
+        "peekOfCode": "class AgentPolicy:\n    def __init__(self, team=\"Red\"):\n        self.team_name = team\n        self.otherteam_name = \"Blue\" if (self.team_name == \"Red\") else \"Red\"\n        self.pos_lookahead = 0.01\n        self.vel_lookahead = 0.01\n        self.start_vel_mag = 0.6\n        self.dribble_speed = 0.5\n        self.dribble_slowdown_dist = 0.25\n        self.dribble_stop_margin_vel_coeff = 0.1",
+        "detail": "vmas.scenarios.football",
+        "documentation": {}
+    },
+    {
+        "label": "ball_action_script",
+        "kind": 2,
+        "importPath": "vmas.scenarios.football",
+        "description": "vmas.scenarios.football",
+        "peekOfCode": "def ball_action_script(ball, world):\n    # Avoid getting stuck against the wall\n    dist_thres = world.agent_size * 2\n    vel_thres = 0.1\n    impulse = 0.01\n    upper = (\n        1\n        - torch.minimum(\n            world.pitch_width / 2 - ball.state.pos[:, 1],\n            torch.tensor(dist_thres, device=world.device),",
+        "detail": "vmas.scenarios.football",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.give_way",
+        "description": "vmas.scenarios.give_way",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.v_range = kwargs.pop(\"v_range\", 0.5)\n        self.a_range = kwargs.pop(\"a_range\", 1)\n        self.obs_noise = kwargs.pop(\"obs_noise\", 0)\n        self.box_agents = kwargs.pop(\"box_agents\", False)\n        self.linear_friction = kwargs.pop(\"linear_friction\", 0.1)\n        self.mirror_passage = kwargs.pop(\"mirror_passage\", False)\n        self.done_on_completion = kwargs.pop(\"done_on_completion\", False)\n        self.observe_rel_pos = kwargs.pop(\"observe_rel_pos\", False)",
+        "detail": "vmas.scenarios.give_way",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.joint_passage",
+        "description": "vmas.scenarios.joint_passage",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_passages = kwargs.pop(\"n_passages\", 1)\n        self.fixed_passage = kwargs.pop(\"fixed_passage\", True)\n        self.joint_length = kwargs.pop(\"joint_length\", 0.5)\n        self.random_start_angle = kwargs.pop(\"random_start_angle\", True)\n        self.random_goal_angle = kwargs.pop(\"random_goal_angle\", True)\n        self.observe_joint_angle = kwargs.pop(\"observe_joint_angle\", False)\n        self.joint_angle_obs_noise = kwargs.pop(\"joint_angle_obs_noise\", 0.0)\n        self.asym_package = kwargs.pop(\"asym_package\", True)",
+        "detail": "vmas.scenarios.joint_passage",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_0_90",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage",
+        "description": "vmas.scenarios.joint_passage",
+        "peekOfCode": "def get_line_angle_0_90(rot: Tensor):\n    angle = torch.abs(rot) % torch.pi\n    other_angle = torch.pi - angle\n    return torch.minimum(angle, other_angle)\ndef get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)",
+        "detail": "vmas.scenarios.joint_passage",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_0_180",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage",
+        "description": "vmas.scenarios.joint_passage",
+        "peekOfCode": "def get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)\n    return torch.minimum(\n        (angle - goal).abs(),\n        torch.minimum(\n            (angle - (goal - torch.pi)).abs(),",
+        "detail": "vmas.scenarios.joint_passage",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_dist_0_180",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage",
+        "description": "vmas.scenarios.joint_passage",
+        "peekOfCode": "def get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)\n    return torch.minimum(\n        (angle - goal).abs(),\n        torch.minimum(\n            (angle - (goal - torch.pi)).abs(),\n            ((angle - torch.pi) - goal).abs(),\n        ),\n    ).squeeze(-1)",
+        "detail": "vmas.scenarios.joint_passage",
+        "documentation": {}
+    },
+    {
+        "label": "angle_to_vector",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage",
+        "description": "vmas.scenarios.joint_passage",
+        "peekOfCode": "def angle_to_vector(angle):\n    return torch.cat([torch.cos(angle), torch.sin(angle)], dim=1)\nclass Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_passages = kwargs.pop(\"n_passages\", 1)\n        self.fixed_passage = kwargs.pop(\"fixed_passage\", True)\n        self.joint_length = kwargs.pop(\"joint_length\", 0.5)\n        self.random_start_angle = kwargs.pop(\"random_start_angle\", True)\n        self.random_goal_angle = kwargs.pop(\"random_goal_angle\", True)\n        self.observe_joint_angle = kwargs.pop(\"observe_joint_angle\", False)",
+        "detail": "vmas.scenarios.joint_passage",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.joint_passage_size",
+        "description": "vmas.scenarios.joint_passage_size",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.fixed_passage = kwargs.pop(\"fixed_passage\", False)\n        self.joint_length = kwargs.pop(\"joint_length\", 0.52)\n        self.random_start_angle = kwargs.pop(\"random_start_angle\", False)\n        self.random_goal_angle = kwargs.pop(\"random_goal_angle\", False)\n        self.observe_joint_angle = kwargs.pop(\"observe_joint_angle\", False)\n        self.joint_angle_obs_noise = kwargs.pop(\"joint_angle_obs_noise\", 0.0)\n        self.asym_package = kwargs.pop(\"asym_package\", False)\n        self.mass_ratio = kwargs.pop(\"mass_ratio\", 1)",
+        "detail": "vmas.scenarios.joint_passage_size",
+        "documentation": {}
+    },
+    {
+        "label": "angle_to_vector",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage_size",
+        "description": "vmas.scenarios.joint_passage_size",
+        "peekOfCode": "def angle_to_vector(angle):\n    return torch.cat([torch.cos(angle), torch.sin(angle)], dim=1)\ndef get_line_angle_0_90(rot: Tensor):\n    angle = torch.abs(rot) % torch.pi\n    other_angle = torch.pi - angle\n    return torch.minimum(angle, other_angle)\ndef get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_360(angle, goal):",
+        "detail": "vmas.scenarios.joint_passage_size",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_0_90",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage_size",
+        "description": "vmas.scenarios.joint_passage_size",
+        "peekOfCode": "def get_line_angle_0_90(rot: Tensor):\n    angle = torch.abs(rot) % torch.pi\n    other_angle = torch.pi - angle\n    return torch.minimum(angle, other_angle)\ndef get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_360(angle, goal):\n    angle = angle_to_vector(angle)\n    goal = angle_to_vector(goal)",
+        "detail": "vmas.scenarios.joint_passage_size",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_0_180",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage_size",
+        "description": "vmas.scenarios.joint_passage_size",
+        "peekOfCode": "def get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_360(angle, goal):\n    angle = angle_to_vector(angle)\n    goal = angle_to_vector(goal)\n    return -torch.einsum(\"bs,bs->b\", angle, goal)\ndef get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)",
+        "detail": "vmas.scenarios.joint_passage_size",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_dist_0_360",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage_size",
+        "description": "vmas.scenarios.joint_passage_size",
+        "peekOfCode": "def get_line_angle_dist_0_360(angle, goal):\n    angle = angle_to_vector(angle)\n    goal = angle_to_vector(goal)\n    return -torch.einsum(\"bs,bs->b\", angle, goal)\ndef get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)\n    return torch.minimum(\n        (angle - goal).abs(),\n        torch.minimum(",
+        "detail": "vmas.scenarios.joint_passage_size",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_dist_0_180",
+        "kind": 2,
+        "importPath": "vmas.scenarios.joint_passage_size",
+        "description": "vmas.scenarios.joint_passage_size",
+        "peekOfCode": "def get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)\n    return torch.minimum(\n        (angle - goal).abs(),\n        torch.minimum(\n            (angle - (goal - torch.pi)).abs(),\n            ((angle - torch.pi) - goal).abs(),\n        ),\n    ).squeeze(-1)",
+        "detail": "vmas.scenarios.joint_passage_size",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.multi_give_way",
+        "description": "vmas.scenarios.multi_give_way",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.u_range = kwargs.pop(\"u_range\", 0.5)\n        self.a_range = kwargs.pop(\"a_range\", 1)\n        self.obs_noise = kwargs.pop(\"obs_noise\", 0)\n        self.box_agents = kwargs.pop(\"box_agents\", False)\n        self.linear_friction = kwargs.pop(\"linear_friction\", 0.1)\n        self.min_input_norm = kwargs.pop(\"min_input_norm\", 0.08)\n        self.comms_range = kwargs.pop(\"comms_range\", 5)\n        self.shared_rew = kwargs.pop(\"shared_rew\", True)",
+        "detail": "vmas.scenarios.multi_give_way",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.navigation",
+        "description": "vmas.scenarios.navigation",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.plot_grid = False\n        self.n_agents = kwargs.pop(\"n_agents\", 4)\n        self.collisions = kwargs.pop(\"collisions\", True)\n        self.agents_with_same_goal = kwargs.pop(\"agents_with_same_goal\", 1)\n        self.split_goals = kwargs.pop(\"split_goals\", False)\n        self.observe_all_goals = kwargs.pop(\"observe_all_goals\", False)\n        self.lidar_range = kwargs.pop(\"lidar_range\", 0.35)\n        self.agent_radius = kwargs.pop(\"agent_radius\", 0.1)",
+        "detail": "vmas.scenarios.navigation",
+        "documentation": {}
+    },
+    {
+        "label": "HeuristicPolicy",
+        "kind": 6,
+        "importPath": "vmas.scenarios.navigation",
+        "description": "vmas.scenarios.navigation",
+        "peekOfCode": "class HeuristicPolicy(BaseHeuristicPolicy):\n    def __init__(self, clf_epsilon=0.2, clf_slack=100.0, *args, **kwargs):\n        super().__init__(*args, **kwargs)\n        self.clf_epsilon = clf_epsilon  # Exponential CLF convergence rate\n        self.clf_slack = clf_slack  # weights on CLF-QP slack variable\n    def compute_action(self, observation: Tensor, u_range: Tensor) -> Tensor:\n        \"\"\"\n        QP inputs:\n        These values need to computed apriri based on observation before passing into QP\n        V: Lyapunov function value",
+        "detail": "vmas.scenarios.navigation",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.passage",
+        "description": "vmas.scenarios.passage",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_passages = kwargs.pop(\"n_passages\", 1)\n        self.shared_reward = kwargs.pop(\"shared_reward\", False)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        assert self.n_passages >= 1 and self.n_passages <= 20\n        self.shaping_factor = 100\n        self.n_agents = 5\n        self.agent_radius = 0.03333\n        self.agent_spacing = 0.1",
+        "detail": "vmas.scenarios.passage",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.reverse_transport",
+        "description": "vmas.scenarios.reverse_transport",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        n_agents = kwargs.pop(\"n_agents\", 4)\n        self.package_width = kwargs.pop(\"package_width\", 0.6)\n        self.package_length = kwargs.pop(\"package_length\", 0.6)\n        self.package_mass = kwargs.pop(\"package_mass\", 50)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.shaping_factor = 100\n        # Make world\n        world = World(",
+        "detail": "vmas.scenarios.reverse_transport",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.sampling",
+        "description": "vmas.scenarios.sampling",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.n_agents = kwargs.pop(\"n_agents\", 3)\n        self.shared_rew = kwargs.pop(\"shared_rew\", True)\n        self.comms_range = kwargs.pop(\"comms_range\", 0.0)\n        self.lidar_range = kwargs.pop(\"lidar_range\", 0.2)\n        self.agent_radius = kwargs.pop(\"agent_radius\", 0.025)\n        self.xdim = kwargs.pop(\"xdim\", 1)\n        self.ydim = kwargs.pop(\"ydim\", 1)\n        self.grid_spacing = kwargs.pop(\"grid_spacing\", 0.05)",
+        "detail": "vmas.scenarios.sampling",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.transport",
+        "description": "vmas.scenarios.transport",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        n_agents = kwargs.pop(\"n_agents\", 4)\n        self.n_packages = kwargs.pop(\"n_packages\", 1)\n        self.package_width = kwargs.pop(\"package_width\", 0.15)\n        self.package_length = kwargs.pop(\"package_length\", 0.15)\n        self.package_mass = kwargs.pop(\"package_mass\", 50)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        self.shaping_factor = 100\n        self.world_semidim = 1",
+        "detail": "vmas.scenarios.transport",
+        "documentation": {}
+    },
+    {
+        "label": "HeuristicPolicy",
+        "kind": 6,
+        "importPath": "vmas.scenarios.transport",
+        "description": "vmas.scenarios.transport",
+        "peekOfCode": "class HeuristicPolicy(BaseHeuristicPolicy):\n    def __init__(self, *args, **kwargs):\n        super().__init__(*args, **kwargs)\n        self.lookahead = 0.0  # evaluate u at this value along the spline\n        self.start_vel_dist_from_target_ratio = (\n            0.5  # distance away from the target for the start_vel to point\n        )\n        self.start_vel_behind_ratio = 0.5  # component of start vel pointing directly behind target (other component is normal)\n        self.start_vel_mag = 1.0  # magnitude of start_vel (determines speed along the whole trajectory, as spline is recalculated continuously)\n        self.hit_vel_mag = 1.0",
+        "detail": "vmas.scenarios.transport",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.wheel",
+        "description": "vmas.scenarios.wheel",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        n_agents = kwargs.pop(\"n_agents\", 4)\n        self.line_length = kwargs.pop(\"line_length\", 2)\n        line_mass = kwargs.pop(\"line_mass\", 30)\n        self.desired_velocity = kwargs.pop(\"desired_velocity\", 0.05)\n        ScenarioUtils.check_kwargs_consumed(kwargs)\n        # Make world\n        world = World(batch_dim, device)\n        # Add agents",
+        "detail": "vmas.scenarios.wheel",
+        "documentation": {}
+    },
+    {
+        "label": "HeuristicPolicy",
+        "kind": 6,
+        "importPath": "vmas.scenarios.wheel",
+        "description": "vmas.scenarios.wheel",
+        "peekOfCode": "class HeuristicPolicy(BaseHeuristicPolicy):\n    def compute_action(self, observation: torch.Tensor, u_range: float) -> torch.Tensor:\n        assert self.continuous_actions is True, \"Heuristic for continuous actions only\"\n        index_line_extrema = 6\n        pos_agent = observation[:, :2]\n        pos_end2_agent = observation[:, index_line_extrema + 2 : index_line_extrema + 4]\n        pos_end2 = pos_end2_agent + pos_agent\n        pos_end2_shifted = TorchUtils.rotate_vector(\n            pos_end2,\n            torch.tensor(torch.pi / 4, device=observation.device).expand(",
+        "detail": "vmas.scenarios.wheel",
+        "documentation": {}
+    },
+    {
+        "label": "Scenario",
+        "kind": 6,
+        "importPath": "vmas.scenarios.wind_flocking",
+        "description": "vmas.scenarios.wind_flocking",
+        "peekOfCode": "class Scenario(BaseScenario):\n    def make_world(self, batch_dim: int, device: torch.device, **kwargs):\n        self.plot_grid = True\n        self.viewer_zoom = 2\n        # Reward\n        self.vel_shaping_factor = kwargs.pop(\"vel_shaping_factor\", 1)\n        self.dist_shaping_factor = kwargs.pop(\"dist_shaping_factor\", 1)\n        self.wind_shaping_factor = kwargs.pop(\"wind_shaping_factor\", 1)\n        self.pos_shaping_factor = kwargs.pop(\"pos_shaping_factor\", 0)\n        self.rot_shaping_factor = kwargs.pop(\"rot_shaping_factor\", 0)",
+        "detail": "vmas.scenarios.wind_flocking",
+        "documentation": {}
+    },
+    {
+        "label": "angle_to_vector",
+        "kind": 2,
+        "importPath": "vmas.scenarios.wind_flocking",
+        "description": "vmas.scenarios.wind_flocking",
+        "peekOfCode": "def angle_to_vector(angle):\n    return torch.cat([torch.cos(angle), torch.sin(angle)], dim=1)\ndef get_line_angle_0_90(rot: Tensor):\n    angle = torch.abs(rot) % torch.pi\n    other_angle = torch.pi - angle\n    return torch.minimum(angle, other_angle)\ndef get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_360(angle, goal):",
+        "detail": "vmas.scenarios.wind_flocking",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_0_90",
+        "kind": 2,
+        "importPath": "vmas.scenarios.wind_flocking",
+        "description": "vmas.scenarios.wind_flocking",
+        "peekOfCode": "def get_line_angle_0_90(rot: Tensor):\n    angle = torch.abs(rot) % torch.pi\n    other_angle = torch.pi - angle\n    return torch.minimum(angle, other_angle)\ndef get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_360(angle, goal):\n    angle = angle_to_vector(angle)\n    goal = angle_to_vector(goal)",
+        "detail": "vmas.scenarios.wind_flocking",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_0_180",
+        "kind": 2,
+        "importPath": "vmas.scenarios.wind_flocking",
+        "description": "vmas.scenarios.wind_flocking",
+        "peekOfCode": "def get_line_angle_0_180(rot):\n    angle = rot % torch.pi\n    return angle\ndef get_line_angle_dist_0_360(angle, goal):\n    angle = angle_to_vector(angle)\n    goal = angle_to_vector(goal)\n    return -torch.einsum(\"bs,bs->b\", angle, goal)\ndef get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)",
+        "detail": "vmas.scenarios.wind_flocking",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_dist_0_360",
+        "kind": 2,
+        "importPath": "vmas.scenarios.wind_flocking",
+        "description": "vmas.scenarios.wind_flocking",
+        "peekOfCode": "def get_line_angle_dist_0_360(angle, goal):\n    angle = angle_to_vector(angle)\n    goal = angle_to_vector(goal)\n    return -torch.einsum(\"bs,bs->b\", angle, goal)\ndef get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)\n    return torch.minimum(\n        (angle - goal).abs(),\n        torch.minimum(",
+        "detail": "vmas.scenarios.wind_flocking",
+        "documentation": {}
+    },
+    {
+        "label": "get_line_angle_dist_0_180",
+        "kind": 2,
+        "importPath": "vmas.scenarios.wind_flocking",
+        "description": "vmas.scenarios.wind_flocking",
+        "peekOfCode": "def get_line_angle_dist_0_180(angle, goal):\n    angle = get_line_angle_0_180(angle)\n    goal = get_line_angle_0_180(goal)\n    return torch.minimum(\n        (angle - goal).abs(),\n        torch.minimum(\n            (angle - (goal - torch.pi)).abs(),\n            ((angle - torch.pi) - goal).abs(),\n        ),\n    ).squeeze(-1)",
+        "detail": "vmas.scenarios.wind_flocking",
+        "documentation": {}
+    },
+    {
+        "label": "VelocityController",
+        "kind": 6,
+        "importPath": "vmas.simulator.controllers.velocity_controller",
+        "description": "vmas.simulator.controllers.velocity_controller",
+        "peekOfCode": "class VelocityController:\n    \"\"\"\n    Implements PID controller for velocity targets found in agent.action.u.\n    Two forms of the PID controller are implemented: standard, and parallel. The controller takes 3 params, which\n    are interpreted differently based on the form.\n    > Standard form: ctrl_params=[gain, intg_ts, derv_ts]\n                        intg_ts: rise time for integrator (err will be tolerated for this interval)\n                        derv_ts: seek time for derivative (err is predicted over this interval)\n                        These are specified in 1/dt scale (0.5 means 0.5/0.1==5sec)\n    > Parallel form: ctrl_params=[kP, kI, kD]",
+        "detail": "vmas.simulator.controllers.velocity_controller",
+        "documentation": {}
+    },
+    {
+        "label": "Dynamics",
+        "kind": 6,
+        "importPath": "vmas.simulator.dynamics.common",
+        "description": "vmas.simulator.dynamics.common",
+        "peekOfCode": "class Dynamics(ABC):\n    def __init__(\n        self,\n    ):\n        self._agent = None\n    def reset(self, index: Union[Tensor, int] = None):\n        return\n    def zero_grad(self):\n        return\n    @property",
+        "detail": "vmas.simulator.dynamics.common",
+        "documentation": {}
+    },
+    {
+        "label": "DiffDrive",
+        "kind": 6,
+        "importPath": "vmas.simulator.dynamics.diff_drive",
+        "description": "vmas.simulator.dynamics.diff_drive",
+        "peekOfCode": "class DiffDrive(Dynamics):\n    def __init__(\n        self,\n        world: vmas.simulator.core.World,\n        integration: str = \"rk4\",  # one of \"euler\", \"rk4\"\n    ):\n        super().__init__()\n        assert integration == \"rk4\" or integration == \"euler\"\n        self.dt = world.dt\n        self.integration = integration",
+        "detail": "vmas.simulator.dynamics.diff_drive",
+        "documentation": {}
+    },
+    {
+        "label": "Drone",
+        "kind": 6,
+        "importPath": "vmas.simulator.dynamics.drone",
+        "description": "vmas.simulator.dynamics.drone",
+        "peekOfCode": "class Drone(Dynamics):\n    def __init__(\n        self,\n        world: vmas.simulator.core.World,\n        I_xx: float = 8.1e-3,\n        I_yy: float = 8.1e-3,\n        I_zz: float = 14.2e-3,\n        integration: str = \"rk4\",\n    ):\n        super().__init__()",
+        "detail": "vmas.simulator.dynamics.drone",
+        "documentation": {}
+    },
+    {
+        "label": "Holonomic",
+        "kind": 6,
+        "importPath": "vmas.simulator.dynamics.holonomic",
+        "description": "vmas.simulator.dynamics.holonomic",
+        "peekOfCode": "class Holonomic(Dynamics):\n    @property\n    def needed_action_size(self) -> int:\n        return 2\n    def process_action(self):\n        self.agent.state.force = self.agent.action.u[:, : self.needed_action_size]",
+        "detail": "vmas.simulator.dynamics.holonomic",
+        "documentation": {}
+    },
+    {
+        "label": "HolonomicWithRotation",
+        "kind": 6,
+        "importPath": "vmas.simulator.dynamics.holonomic_with_rot",
+        "description": "vmas.simulator.dynamics.holonomic_with_rot",
+        "peekOfCode": "class HolonomicWithRotation(Dynamics):\n    @property\n    def needed_action_size(self) -> int:\n        return 3\n    def process_action(self):\n        self.agent.state.force = self.agent.action.u[:, :2]\n        self.agent.state.torque = self.agent.action.u[:, 2].unsqueeze(-1)",
+        "detail": "vmas.simulator.dynamics.holonomic_with_rot",
+        "documentation": {}
+    },
+    {
+        "label": "KinematicBicycle",
+        "kind": 6,
+        "importPath": "vmas.simulator.dynamics.kinematic_bicycle",
+        "description": "vmas.simulator.dynamics.kinematic_bicycle",
+        "peekOfCode": "class KinematicBicycle(Dynamics):\n    # For the implementation of the kinematic bicycle model, see the equation (2) of the paper Polack, Philip, et al. \"The kinematic bicycle model: A consistent model for planning feasible trajectories for autonomous vehicles?.\" 2017 IEEE intelligent vehicles symposium (IV). IEEE, 2017.\n    def __init__(\n        self,\n        world: vmas.simulator.core.World,\n        width: float,\n        l_f: float,\n        l_r: float,\n        max_steering_angle: float,\n        integration: str = \"rk4\",  # one of \"euler\", \"rk4\"",
+        "detail": "vmas.simulator.dynamics.kinematic_bicycle",
+        "documentation": {}
+    },
+    {
+        "label": "Environment",
+        "kind": 6,
+        "importPath": "vmas.simulator.environment.environment",
+        "description": "vmas.simulator.environment.environment",
+        "peekOfCode": "class Environment(TorchVectorizedObject):\n    metadata = {\n        \"render.modes\": [\"human\", \"rgb_array\"],\n        \"runtime.vectorized\": True,\n    }\n    def __init__(\n        self,\n        scenario: BaseScenario,\n        num_envs: int = 32,\n        device: DEVICE_TYPING = \"cpu\",",
+        "detail": "vmas.simulator.environment.environment",
+        "documentation": {}
+    },
+    {
+        "label": "GymWrapper",
+        "kind": 6,
+        "importPath": "vmas.simulator.environment.gym",
+        "description": "vmas.simulator.environment.gym",
+        "peekOfCode": "class GymWrapper(gym.Env):\n    metadata = Environment.metadata\n    def __init__(\n        self,\n        env: Environment,\n    ):\n        assert (\n            env.num_envs == 1\n        ), f\"GymEnv wrapper is not vectorised, got env.num_envs: {env.num_envs}\"\n        self._env = env",
+        "detail": "vmas.simulator.environment.gym",
+        "documentation": {}
+    },
+    {
+        "label": "VectorEnvWrapper",
+        "kind": 6,
+        "importPath": "vmas.simulator.environment.rllib",
+        "description": "vmas.simulator.environment.rllib",
+        "peekOfCode": "class VectorEnvWrapper(rllib.VectorEnv):\n    \"\"\"\n    Vector environment wrapper for rllib\n    \"\"\"\n    def __init__(\n        self,\n        env: Environment,\n    ):\n        self._env = env\n        super().__init__(",
+        "detail": "vmas.simulator.environment.rllib",
+        "documentation": {}
+    },
+    {
+        "label": "TorchVectorizedObject",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class TorchVectorizedObject(object):\n    def __init__(self, batch_dim: int = None, device: torch.device = None):\n        # batch dim\n        self._batch_dim = batch_dim\n        # device\n        self._device = device\n    @property\n    def batch_dim(self):\n        return self._batch_dim\n    @batch_dim.setter",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Shape",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class Shape(ABC):\n    @abstractmethod\n    def moment_of_inertia(self, mass: float):\n        raise NotImplementedError\n    @abstractmethod\n    def get_delta_from_anchor(self, anchor: Tuple[float, float]) -> Tuple[float, float]:\n        raise NotImplementedError\n    @abstractmethod\n    def get_geometry(self):\n        raise NotImplementedError",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Box",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class Box(Shape):\n    def __init__(self, length: float = 0.3, width: float = 0.1, hollow: bool = False):\n        super().__init__()\n        assert length > 0, f\"Length must be > 0, got {length}\"\n        assert width > 0, f\"Width must be > 0, got {length}\"\n        self._length = length\n        self._width = width\n        self.hollow = hollow\n    @property\n    def length(self):",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Sphere",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class Sphere(Shape):\n    def __init__(self, radius: float = 0.05):\n        super().__init__()\n        assert radius > 0, f\"Radius must be > 0, got {radius}\"\n        self._radius = radius\n    @property\n    def radius(self):\n        return self._radius\n    def get_delta_from_anchor(self, anchor: Tuple[float, float]) -> Tuple[float, float]:\n        delta = torch.tensor([anchor[X] * self.radius, anchor[Y] * self.radius]).to(",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class Line(Shape):\n    def __init__(self, length: float = 0.5):\n        super().__init__()\n        assert length > 0, f\"Length must be > 0, got {length}\"\n        self._length = length\n        self._width = 2\n    @property\n    def length(self):\n        return self._length\n    @property",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "EntityState",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class EntityState(TorchVectorizedObject):\n    def __init__(self):\n        super().__init__()\n        # physical position\n        self._pos = None\n        # physical velocity\n        self._vel = None\n        # physical rotation -- from -pi to pi\n        self._rot = None\n        # angular velocity",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "AgentState",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class AgentState(EntityState):\n    def __init__(\n        self,\n    ):\n        super().__init__()\n        # communication utterance\n        self._c = None\n        # Agent force from actions\n        self._force = None\n        # Agent torque from actions",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Action",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class Action(TorchVectorizedObject):\n    def __init__(\n        self,\n        u_range: Union[float, Sequence[float]],\n        u_multiplier: Union[float, Sequence[float]],\n        u_noise: Union[float, Sequence[float]],\n        action_size: int,\n    ):\n        super().__init__()\n        # physical motor noise amount",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Entity",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class Entity(TorchVectorizedObject, Observable, ABC):\n    def __init__(\n        self,\n        name: str,\n        movable: bool = False,\n        rotatable: bool = False,\n        collide: bool = True,\n        density: float = 25.0,  # Unused for now\n        mass: float = 1.0,\n        shape: Shape = None,",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Landmark",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class Landmark(Entity):\n    def __init__(\n        self,\n        name: str,\n        shape: Shape = None,\n        movable: bool = False,\n        rotatable: bool = False,\n        collide: bool = True,\n        density: float = 25.0,  # Unused for now\n        mass: float = 1.0,",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "Agent",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class Agent(Entity):\n    def __init__(\n        self,\n        name: str,\n        shape: Shape = None,\n        movable: bool = True,\n        rotatable: bool = True,\n        collide: bool = True,\n        density: float = 25.0,  # Unused for now\n        mass: float = 1.0,",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "World",
+        "kind": 6,
+        "importPath": "vmas.simulator.core",
+        "description": "vmas.simulator.core",
+        "peekOfCode": "class World(TorchVectorizedObject):\n    def __init__(\n        self,\n        batch_dim: int,\n        device: torch.device,\n        dt: float = 0.1,\n        substeps: int = 1,  # if you use joints, higher this value to gain simulation stability\n        drag: float = DRAG,\n        linear_friction: float = LINEAR_FRICTION,\n        angular_friction: float = ANGULAR_FRICTION,",
+        "detail": "vmas.simulator.core",
+        "documentation": {}
+    },
+    {
+        "label": "BaseHeuristicPolicy",
+        "kind": 6,
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "peekOfCode": "class BaseHeuristicPolicy(ABC):\n    def __init__(self, continuous_action: bool):\n        self.continuous_actions = continuous_action\n    @abstractmethod\n    def compute_action(self, observation: torch.Tensor, u_range: float) -> torch.Tensor:\n        raise NotImplementedError\nclass RandomPolicy(BaseHeuristicPolicy):\n    def compute_action(self, observation: torch.Tensor, u_range: float) -> torch.Tensor:\n        n_envs = observation.shape[0]\n        return torch.clamp(torch.randn(n_envs, 2), -u_range, u_range)",
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "RandomPolicy",
+        "kind": 6,
+        "importPath": "vmas.simulator.heuristic_policy",
+        "description": "vmas.simulator.heuristic_policy",
+        "peekOfCode": "class RandomPolicy(BaseHeuristicPolicy):\n    def compute_action(self, observation: torch.Tensor, u_range: float) -> torch.Tensor:\n        n_envs = observation.shape[0]\n        return torch.clamp(torch.randn(n_envs, 2), -u_range, u_range)",
+        "detail": "vmas.simulator.heuristic_policy",
+        "documentation": {}
+    },
+    {
+        "label": "Joint",
+        "kind": 6,
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "peekOfCode": "class Joint(vmas.simulator.utils.Observer):\n    def __init__(\n        self,\n        entity_a: vmas.simulator.core.Entity,\n        entity_b: vmas.simulator.core.Entity,\n        anchor_a: Tuple[float, float] = (0.0, 0.0),\n        anchor_b: Tuple[float, float] = (0.0, 0.0),\n        rotate_a: bool = True,\n        rotate_b: bool = True,\n        dist: float = 0.0,",
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "JointConstraint",
+        "kind": 6,
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "peekOfCode": "class JointConstraint:\n    \"\"\"\n    This is an uncollidable constraint that bounds two entities in the specified anchor points at the specified distance\n    \"\"\"\n    def __init__(\n        self,\n        entity_a: vmas.simulator.core.Entity,\n        entity_b: vmas.simulator.core.Entity,\n        anchor_a: Tuple[float, float] = (0.0, 0.0),\n        anchor_b: Tuple[float, float] = (0.0, 0.0),",
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "UNCOLLIDABLE_JOINT_RENDERING_WIDTH",
+        "kind": 5,
+        "importPath": "vmas.simulator.joints",
+        "description": "vmas.simulator.joints",
+        "peekOfCode": "UNCOLLIDABLE_JOINT_RENDERING_WIDTH = 1\nclass Joint(vmas.simulator.utils.Observer):\n    def __init__(\n        self,\n        entity_a: vmas.simulator.core.Entity,\n        entity_b: vmas.simulator.core.Entity,\n        anchor_a: Tuple[float, float] = (0.0, 0.0),\n        anchor_b: Tuple[float, float] = (0.0, 0.0),\n        rotate_a: bool = True,\n        rotate_b: bool = True,",
+        "detail": "vmas.simulator.joints",
+        "documentation": {}
+    },
+    {
+        "label": "Viewer",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Viewer(object):\n    def __init__(self, width, height, display=None, visible=True):\n        display = get_display(display)\n        self.width = width\n        self.height = height\n        self.window = pyglet.window.Window(\n            width=width, height=height, display=display, visible=visible\n        )\n        self.window.on_close = self.window_closed_by_user\n        self.geoms = []",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Geom",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Geom(object):\n    def __init__(self):\n        self._color = Color((0, 0, 0, 1.0))\n        self.attrs = [self._color]\n    def render(self):\n        for attr in reversed(self.attrs):\n            attr.enable()\n        self.render1()\n        for attr in self.attrs:\n            attr.disable()",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Attr",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Attr(object):\n    def enable(self):\n        raise NotImplementedError\n    def disable(self):\n        pass\nclass Transform(Attr):\n    def __init__(self, translation=(0.0, 0.0), rotation=0.0, scale=(1, 1)):\n        self.set_translation(*translation)\n        self.set_rotation(rotation)\n        self.set_scale(*scale)",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Transform",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Transform(Attr):\n    def __init__(self, translation=(0.0, 0.0), rotation=0.0, scale=(1, 1)):\n        self.set_translation(*translation)\n        self.set_rotation(rotation)\n        self.set_scale(*scale)\n    def enable(self):\n        glPushMatrix()\n        glTranslatef(\n            self.translation[0], self.translation[1], 0\n        )  # translate to GL loc ppint",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Color(Attr):\n    def __init__(self, vec4):\n        self.vec4 = vec4\n    def enable(self):\n        glColor4f(*self.vec4)\nclass LineStyle(Attr):\n    def __init__(self, style):\n        self.style = style\n    def enable(self):\n        glEnable(GL_LINE_STIPPLE)",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "LineStyle",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class LineStyle(Attr):\n    def __init__(self, style):\n        self.style = style\n    def enable(self):\n        glEnable(GL_LINE_STIPPLE)\n        glLineStipple(1, self.style)\n    def disable(self):\n        glDisable(GL_LINE_STIPPLE)\nclass LineWidth(Attr):\n    def __init__(self, stroke):",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "LineWidth",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class LineWidth(Attr):\n    def __init__(self, stroke):\n        self.stroke = stroke\n    def enable(self):\n        glLineWidth(self.stroke)\nclass TextLine(Geom):\n    def __init__(\n        self,\n        text: str = \"\",\n        font_size: int = 15,",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "TextLine",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class TextLine(Geom):\n    def __init__(\n        self,\n        text: str = \"\",\n        font_size: int = 15,\n        x: float = 0.0,\n        y: float = 0.0,\n    ):\n        super().__init__()\n        if pyglet.font.have_font(\"Courier\"):",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Point",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Point(Geom):\n    def __init__(self):\n        Geom.__init__(self)\n    def render1(self):\n        glBegin(GL_POINTS)  # draw point\n        glVertex3f(0.0, 0.0, 0.0)\n        glEnd()\nclass Image(Geom):\n    def __init__(self, img, x, y, scale):\n        super().__init__()",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Image",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Image(Geom):\n    def __init__(self, img, x, y, scale):\n        super().__init__()\n        self.x = x\n        self.y = y\n        self.scale = scale\n        img_shape = img.shape\n        img = img.astype(np.uint8).reshape(-1)\n        tex_data = (pyglet.gl.GLubyte * img.size)(*img)\n        pyg_img = pyglet.image.ImageData(",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "FilledPolygon",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class FilledPolygon(Geom):\n    def __init__(self, v, draw_border: float = True):\n        Geom.__init__(self)\n        self.draw_border = draw_border\n        self.v = v\n    def render1(self):\n        if len(self.v) == 4:\n            glBegin(GL_QUADS)\n        elif len(self.v) > 4:\n            glBegin(GL_POLYGON)",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Compound",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Compound(Geom):\n    def __init__(self, gs):\n        Geom.__init__(self)\n        self.gs = gs\n        for g in self.gs:\n            g.attrs = [a for a in g.attrs if not isinstance(a, Color)]\n    def render1(self):\n        for g in self.gs:\n            g.render()\nclass PolyLine(Geom):",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "PolyLine",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class PolyLine(Geom):\n    def __init__(self, v, close):\n        Geom.__init__(self)\n        self.v = v\n        self.close = close\n        self.linewidth = LineWidth(1)\n        self.add_attr(self.linewidth)\n    def render1(self):\n        glBegin(GL_LINE_LOOP if self.close else GL_LINE_STRIP)\n        for p in self.v:",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Line",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Line(Geom):\n    def __init__(self, start=(0.0, 0.0), end=(0.0, 0.0), width: float = 1):\n        Geom.__init__(self)\n        self.start = start\n        self.end = end\n        self.linewidth = LineWidth(width)\n        self.add_attr(self.linewidth)\n    def set_linewidth(self, x):\n        self.linewidth.stroke = x\n    def render1(self):",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "Grid",
+        "kind": 6,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "class Grid(Geom):\n    def __init__(self, spacing: float = 0.1, length: float = 50, width: float = 0.5):\n        Geom.__init__(self)\n        self.spacing = spacing\n        self.linewidth = LineWidth(width)\n        self.length = length\n        self.add_attr(self.linewidth)\n    def set_linewidth(self, x):\n        self.linewidth.stroke = x\n    def render1(self):",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "get_display",
+        "kind": 2,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "def get_display(spec):\n    \"\"\"Convert a display specification (such as :0) into an actual Display\n    object.\n    Pyglet only supports multiple Displays on Linux.\n    \"\"\"\n    if spec is None:\n        return None\n    elif isinstance(spec, six.string_types):\n        return pyglet.canvas.Display(spec)\n    else:",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "render_function_util",
+        "kind": 2,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "def render_function_util(\n    f: Callable,\n    plot_range: Union[\n        float,\n        Tuple[float, float],\n        Tuple[Tuple[float, float], Tuple[float, float]],\n    ],\n    precision: float = 0.01,\n    cmap_range: Optional[Tuple[float, float]] = None,\n    cmap_alpha: float = 1.0,",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "make_circle",
+        "kind": 2,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "def make_circle(radius=10, res=30, filled=True, angle=2 * math.pi):\n    points = []\n    for i in range(res):\n        ang = -angle / 2 + angle * i / res\n        points.append((math.cos(ang) * radius, math.sin(ang) * radius))\n    if angle % (2 * math.pi) != 0:\n        points.append((0, 0))\n    if filled:\n        return FilledPolygon(points)\n    else:",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "make_polygon",
+        "kind": 2,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "def make_polygon(v, filled=True, draw_border: float = True):\n    if filled:\n        return FilledPolygon(v, draw_border=draw_border)\n    else:\n        return PolyLine(v, True)\ndef make_polyline(v):\n    return PolyLine(v, False)\ndef make_capsule(length, width):\n    l, r, t, b = 0, length, width / 2, -width / 2\n    box = make_polygon([(l, b), (l, t), (r, t), (r, b)])",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "make_polyline",
+        "kind": 2,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "def make_polyline(v):\n    return PolyLine(v, False)\ndef make_capsule(length, width):\n    l, r, t, b = 0, length, width / 2, -width / 2\n    box = make_polygon([(l, b), (l, t), (r, t), (r, b)])\n    circ0 = make_circle(width / 2)\n    circ1 = make_circle(width / 2)\n    circ1.add_attr(Transform(translation=(length, 0)))\n    geom = Compound([box, circ0, circ1])\n    return geom",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "make_capsule",
+        "kind": 2,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "def make_capsule(length, width):\n    l, r, t, b = 0, length, width / 2, -width / 2\n    box = make_polygon([(l, b), (l, t), (r, t), (r, b)])\n    circ0 = make_circle(width / 2)\n    circ1 = make_circle(width / 2)\n    circ1.add_attr(Transform(translation=(length, 0)))\n    geom = Compound([box, circ0, circ1])\n    return geom\n# ================================================================",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "RAD2DEG",
+        "kind": 5,
+        "importPath": "vmas.simulator.rendering",
+        "description": "vmas.simulator.rendering",
+        "peekOfCode": "RAD2DEG = 57.29577951308232\ndef get_display(spec):\n    \"\"\"Convert a display specification (such as :0) into an actual Display\n    object.\n    Pyglet only supports multiple Displays on Linux.\n    \"\"\"\n    if spec is None:\n        return None\n    elif isinstance(spec, six.string_types):\n        return pyglet.canvas.Display(spec)",
+        "detail": "vmas.simulator.rendering",
+        "documentation": {}
+    },
+    {
+        "label": "BaseScenario",
+        "kind": 6,
+        "importPath": "vmas.simulator.scenario",
+        "description": "vmas.simulator.scenario",
+        "peekOfCode": "class BaseScenario(ABC):\n    \"\"\"Base class for scenarios.\n    This is the class that scenarios inherit from.\n    The methods that are **compulsory to instantiate** are:\n    - :class:`make_world`\n    - :class:`reset_world_at`\n    - :class:`observation`\n    - :class:`reward`\n    The methods that are **optional to instantiate** are:\n    - :class:`info`",
+        "detail": "vmas.simulator.scenario",
+        "documentation": {}
+    },
+    {
+        "label": "Sensor",
+        "kind": 6,
+        "importPath": "vmas.simulator.sensors",
+        "description": "vmas.simulator.sensors",
+        "peekOfCode": "class Sensor(ABC):\n    def __init__(self, world: vmas.simulator.core.World):\n        super().__init__()\n        self._world = world\n        self._agent: Union[vmas.simulator.core.Agent, None] = None\n    @property\n    def agent(self) -> Union[vmas.simulator.core.Agent, None]:\n        return self._agent\n    @agent.setter\n    def agent(self, agent: vmas.simulator.core.Agent):",
+        "detail": "vmas.simulator.sensors",
+        "documentation": {}
+    },
+    {
+        "label": "Lidar",
+        "kind": 6,
+        "importPath": "vmas.simulator.sensors",
+        "description": "vmas.simulator.sensors",
+        "peekOfCode": "class Lidar(Sensor):\n    def __init__(\n        self,\n        world: vmas.simulator.core.World,\n        angle_start: float = 0.0,\n        angle_end: float = 2 * torch.pi,\n        n_rays: int = 8,\n        max_range: float = 1.0,\n        entity_filter: Callable[[vmas.simulator.core.Entity], bool] = lambda _: True,\n        render_color: Union[Color, Tuple[float, float, float]] = Color.GRAY,",
+        "detail": "vmas.simulator.sensors",
+        "documentation": {}
+    },
+    {
+        "label": "Color",
+        "kind": 6,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "class Color(Enum):\n    RED = (0.75, 0.25, 0.25)\n    GREEN = (0.25, 0.75, 0.25)\n    BLUE = (0.25, 0.25, 0.75)\n    LIGHT_GREEN = (0.45, 0.95, 0.45)\n    WHITE = (0.75, 0.75, 0.75)\n    GRAY = (0.25, 0.25, 0.25)\n    BLACK = (0.15, 0.15, 0.15)\ndef override(cls):\n    \"\"\"Decorator for documenting method overrides.\"\"\"",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Observable",
+        "kind": 6,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "class Observable:\n    def __init__(self):\n        self._observers = []\n    def subscribe(self, observer):\n        self._observers.append(observer)\n    def notify_observers(self, *args, **kwargs):\n        for obs in self._observers:\n            obs.notify(self, *args, **kwargs)\n    def unsubscribe(self, observer):\n        self._observers.remove(observer)",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Observer",
+        "kind": 6,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "class Observer(ABC):\n    @abstractmethod\n    def notify(self, observable, *args, **kwargs):\n        raise NotImplementedError\ndef save_video(name: str, frame_list: List[np.array], fps: int):\n    \"\"\"Requres cv2\"\"\"\n    import cv2\n    video_name = name + \".mp4\"\n    # Produce a video\n    video = cv2.VideoWriter(",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TorchUtils",
+        "kind": 6,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "class TorchUtils:\n    @staticmethod\n    def clamp_with_norm(tensor: Tensor, max_norm: float):\n        norm = torch.linalg.vector_norm(tensor, dim=-1)\n        new_tensor = (tensor / norm.unsqueeze(-1)) * max_norm\n        cond = (norm > max_norm).unsqueeze(-1).expand(tensor.shape)\n        tensor = torch.where(cond, new_tensor, tensor)\n        return tensor\n    @staticmethod\n    def rotate_vector(vector: Tensor, angle: Tensor):",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ScenarioUtils",
+        "kind": 6,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "class ScenarioUtils:\n    @staticmethod\n    def spawn_entities_randomly(\n        entities,\n        world,\n        env_index: int,\n        min_dist_between_entities: float,\n        x_bounds: Tuple[int, int],\n        y_bounds: Tuple[int, int],\n        occupied_positions: Tensor = None,",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "override",
+        "kind": 2,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "def override(cls):\n    \"\"\"Decorator for documenting method overrides.\"\"\"\n    def check_override(method):\n        if method.__name__ not in dir(cls):\n            raise NameError(\"{} does not override any method of {}\".format(method, cls))\n        return method\n    return check_override\ndef _init_pyglet_device():\n    available_devices = os.getenv(\"CUDA_VISIBLE_DEVICES\")\n    if available_devices is not None and len(available_devices) > 0:",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "save_video",
+        "kind": 2,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "def save_video(name: str, frame_list: List[np.array], fps: int):\n    \"\"\"Requres cv2\"\"\"\n    import cv2\n    video_name = name + \".mp4\"\n    # Produce a video\n    video = cv2.VideoWriter(\n        video_name,\n        cv2.VideoWriter_fourcc(*\"mp4v\"),\n        fps,  # FPS\n        (frame_list[0].shape[1], frame_list[0].shape[0]),",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "x_to_rgb_colormap",
+        "kind": 2,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "def x_to_rgb_colormap(\n    x: np.ndarray,\n    low: float = None,\n    high: float = None,\n    alpha: float = 1.0,\n    cmap_name: str = \"viridis\",\n    cmap_res: int = 10,\n):\n    from matplotlib import cm\n    colormap = cm.get_cmap(cmap_name, cmap_res)(range(cmap_res))[:, :-1]",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "extract_nested_with_index",
+        "kind": 2,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "def extract_nested_with_index(data: Union[Tensor, Dict[str, Tensor]], index: int):\n    if isinstance(data, Tensor):\n        return data[index]\n    elif isinstance(data, Dict):\n        return {\n            key: extract_nested_with_index(value, index) for key, value in data.items()\n        }\n    else:\n        raise NotImplementedError(f\"Invalid type of data {data}\")\nclass TorchUtils:",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "_has_matplotlib",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "_has_matplotlib = importlib.util.find_spec(\"matplotlib\") is not None\nX = 0\nY = 1\nZ = 2\nALPHABET = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nVIEWER_DEFAULT_ZOOM = 1.2\nINITIAL_VIEWER_SIZE = (700, 700)\nLINE_MIN_DIST = 4 / 6e2\nCOLLISION_FORCE = 100\nJOINT_FORCE = 130",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "X",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "X = 0\nY = 1\nZ = 2\nALPHABET = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nVIEWER_DEFAULT_ZOOM = 1.2\nINITIAL_VIEWER_SIZE = (700, 700)\nLINE_MIN_DIST = 4 / 6e2\nCOLLISION_FORCE = 100\nJOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Y",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "Y = 1\nZ = 2\nALPHABET = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nVIEWER_DEFAULT_ZOOM = 1.2\nINITIAL_VIEWER_SIZE = (700, 700)\nLINE_MIN_DIST = 4 / 6e2\nCOLLISION_FORCE = 100\nJOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "Z",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "Z = 2\nALPHABET = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nVIEWER_DEFAULT_ZOOM = 1.2\nINITIAL_VIEWER_SIZE = (700, 700)\nLINE_MIN_DIST = 4 / 6e2\nCOLLISION_FORCE = 100\nJOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25\nLINEAR_FRICTION = 0.0",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ALPHABET",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "ALPHABET = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nVIEWER_DEFAULT_ZOOM = 1.2\nINITIAL_VIEWER_SIZE = (700, 700)\nLINE_MIN_DIST = 4 / 6e2\nCOLLISION_FORCE = 100\nJOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25\nLINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "VIEWER_DEFAULT_ZOOM",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "VIEWER_DEFAULT_ZOOM = 1.2\nINITIAL_VIEWER_SIZE = (700, 700)\nLINE_MIN_DIST = 4 / 6e2\nCOLLISION_FORCE = 100\nJOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25\nLINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "INITIAL_VIEWER_SIZE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "INITIAL_VIEWER_SIZE = (700, 700)\nLINE_MIN_DIST = 4 / 6e2\nCOLLISION_FORCE = 100\nJOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25\nLINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "LINE_MIN_DIST",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "LINE_MIN_DIST = 4 / 6e2\nCOLLISION_FORCE = 100\nJOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25\nLINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "COLLISION_FORCE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "COLLISION_FORCE = 100\nJOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25\nLINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "JOINT_FORCE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "JOINT_FORCE = 130\nTORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25\nLINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "TORQUE_CONSTRAINT_FORCE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "TORQUE_CONSTRAINT_FORCE = 1\nDRAG = 0.25\nLINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "DRAG",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "DRAG = 0.25\nLINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "LINEAR_FRICTION",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "LINEAR_FRICTION = 0.0\nANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "ANGULAR_FRICTION",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "ANGULAR_FRICTION = 0.0\nDEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor\nclass Color(Enum):",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "DEVICE_TYPING",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "DEVICE_TYPING = Union[torch.device, str, int]\nAGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor\nclass Color(Enum):\n    RED = (0.75, 0.25, 0.25)",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "AGENT_OBS_TYPE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "AGENT_OBS_TYPE = Union[Tensor, Dict[str, Tensor]]\nAGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor\nclass Color(Enum):\n    RED = (0.75, 0.25, 0.25)\n    GREEN = (0.25, 0.75, 0.25)",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "AGENT_INFO_TYPE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "AGENT_INFO_TYPE = Dict[str, Tensor]\nAGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor\nclass Color(Enum):\n    RED = (0.75, 0.25, 0.25)\n    GREEN = (0.25, 0.75, 0.25)\n    BLUE = (0.25, 0.25, 0.75)",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "AGENT_REWARD_TYPE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "AGENT_REWARD_TYPE = Tensor\nOBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor\nclass Color(Enum):\n    RED = (0.75, 0.25, 0.25)\n    GREEN = (0.25, 0.75, 0.25)\n    BLUE = (0.25, 0.25, 0.75)\n    LIGHT_GREEN = (0.45, 0.95, 0.45)",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "OBS_TYPE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "OBS_TYPE = Union[List[AGENT_OBS_TYPE], Dict[str, AGENT_OBS_TYPE]]\nINFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor\nclass Color(Enum):\n    RED = (0.75, 0.25, 0.25)\n    GREEN = (0.25, 0.75, 0.25)\n    BLUE = (0.25, 0.25, 0.75)\n    LIGHT_GREEN = (0.45, 0.95, 0.45)\n    WHITE = (0.75, 0.75, 0.75)",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "INFO_TYPE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "INFO_TYPE = Union[List[AGENT_INFO_TYPE], Dict[str, AGENT_INFO_TYPE]]\nREWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor\nclass Color(Enum):\n    RED = (0.75, 0.25, 0.25)\n    GREEN = (0.25, 0.75, 0.25)\n    BLUE = (0.25, 0.25, 0.75)\n    LIGHT_GREEN = (0.45, 0.95, 0.45)\n    WHITE = (0.75, 0.75, 0.75)\n    GRAY = (0.25, 0.25, 0.25)",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "REWARD_TYPE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "REWARD_TYPE = Union[List[AGENT_REWARD_TYPE], Dict[str, AGENT_REWARD_TYPE]]\nDONE_TYPE = Tensor\nclass Color(Enum):\n    RED = (0.75, 0.25, 0.25)\n    GREEN = (0.25, 0.75, 0.25)\n    BLUE = (0.25, 0.25, 0.75)\n    LIGHT_GREEN = (0.45, 0.95, 0.45)\n    WHITE = (0.75, 0.75, 0.75)\n    GRAY = (0.25, 0.25, 0.25)\n    BLACK = (0.15, 0.15, 0.15)",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "DONE_TYPE",
+        "kind": 5,
+        "importPath": "vmas.simulator.utils",
+        "description": "vmas.simulator.utils",
+        "peekOfCode": "DONE_TYPE = Tensor\nclass Color(Enum):\n    RED = (0.75, 0.25, 0.25)\n    GREEN = (0.25, 0.75, 0.25)\n    BLUE = (0.25, 0.25, 0.75)\n    LIGHT_GREEN = (0.45, 0.95, 0.45)\n    WHITE = (0.75, 0.75, 0.75)\n    GRAY = (0.25, 0.25, 0.25)\n    BLACK = (0.15, 0.15, 0.15)\ndef override(cls):",
+        "detail": "vmas.simulator.utils",
+        "documentation": {}
+    },
+    {
+        "label": "InteractiveEnv",
+        "kind": 6,
+        "importPath": "vmas.interactive_rendering",
+        "description": "vmas.interactive_rendering",
+        "peekOfCode": "class InteractiveEnv:\n    \"\"\"\n    Use this script to interactively play with scenarios\n    You can change agent by pressing TAB\n    You can reset the environment by pressing R\n    You can control agent actions with the arrow keys and M/N (left/right control the first action, up/down control the second, M/N controls the third)\n    If you have more than 1 agent, you can control another one with W,A,S,D and Q,E in the same way.\n    and switch the agent with these controls using LSHIFT\n    \"\"\"\n    def __init__(",
+        "detail": "vmas.interactive_rendering",
+        "documentation": {}
+    },
+    {
+        "label": "render_interactively",
+        "kind": 2,
+        "importPath": "vmas.interactive_rendering",
+        "description": "vmas.interactive_rendering",
+        "peekOfCode": "def render_interactively(\n    scenario: Union[str, BaseScenario],\n    control_two_agents: bool = False,\n    display_info: bool = True,\n    save_render: bool = False,\n    **kwargs,\n):\n    \"\"\"Executes a scenario and renders it so that you can debug and control agents interactively.\n    You can change the agent to control by pressing TAB.\n    You can reset the environment by pressing R.",
+        "detail": "vmas.interactive_rendering",
+        "documentation": {}
+    },
+    {
+        "label": "N_TEXT_LINES_INTERACTIVE",
+        "kind": 5,
+        "importPath": "vmas.interactive_rendering",
+        "description": "vmas.interactive_rendering",
+        "peekOfCode": "N_TEXT_LINES_INTERACTIVE = 6\nclass InteractiveEnv:\n    \"\"\"\n    Use this script to interactively play with scenarios\n    You can change agent by pressing TAB\n    You can reset the environment by pressing R\n    You can control agent actions with the arrow keys and M/N (left/right control the first action, up/down control the second, M/N controls the third)\n    If you have more than 1 agent, you can control another one with W,A,S,D and Q,E in the same way.\n    and switch the agent with these controls using LSHIFT\n    \"\"\"",
+        "detail": "vmas.interactive_rendering",
+        "documentation": {}
+    },
+    {
+        "label": "make_env",
+        "kind": 2,
+        "importPath": "vmas.make_env",
+        "description": "vmas.make_env",
+        "peekOfCode": "def make_env(\n    scenario: Union[str, BaseScenario],\n    num_envs: int,\n    device: DEVICE_TYPING = \"cpu\",\n    continuous_actions: bool = True,\n    wrapper: Optional[\n        Wrapper\n    ] = None,  # One of: None, vmas.Wrapper.RLLIB, and vmas.Wrapper.GYM\n    max_steps: Optional[int] = None,\n    seed: Optional[int] = None,",
+        "detail": "vmas.make_env",
+        "documentation": {}
+    },
+    {
+        "label": "get_version",
+        "kind": 2,
+        "importPath": "setup",
+        "description": "setup",
+        "peekOfCode": "def get_version():\n    \"\"\"Gets the vmas version.\"\"\"\n    path = CWD / \"vmas\" / \"__init__.py\"\n    content = path.read_text()\n    for line in content.splitlines():\n        if line.startswith(\"__version__\"):\n            return line.strip().split()[-1].strip().strip('\"')\n    raise RuntimeError(\"bad version data in __init__.py\")\nCWD = pathlib.Path(__file__).absolute().parent\nsetup(",
+        "detail": "setup",
+        "documentation": {}
+    },
+    {
+        "label": "CWD",
+        "kind": 5,
+        "importPath": "setup",
+        "description": "setup",
+        "peekOfCode": "CWD = pathlib.Path(__file__).absolute().parent\nsetup(\n    name=\"vmas\",\n    version=get_version(),\n    description=\"Vectorized Multi-Agent Simulator\",\n    url=\"https://github.com/proroklab/VectorizedMultiAgentSimulator\",\n    license=\"GPLv3\",\n    author=\"Matteo Bettini\",\n    author_email=\"mb2389@cl.cam.ac.uk\",\n    packages=find_packages(),",
+        "detail": "setup",
+        "documentation": {}
+    }
+]

--- a/vmas/scenarios/debug/lidar_test.py
+++ b/vmas/scenarios/debug/lidar_test.py
@@ -1,0 +1,132 @@
+#  Copyright (c) 2022-2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+import typing
+from typing import List
+
+import torch
+
+from vmas import render_interactively
+from vmas.simulator.core import Agent, Box, Landmark, Line, Sphere, World
+from vmas.simulator.dynamics.diff_drive import DiffDrive
+from vmas.simulator.scenario import BaseScenario
+from vmas.simulator.sensors import Lidar
+from vmas.simulator.utils import Color, ScenarioUtils
+
+if typing.TYPE_CHECKING:
+    from vmas.simulator.rendering import Geom
+
+
+class Scenario(BaseScenario):
+    def make_world(self, batch_dim: int, device: torch.device, **kwargs):
+        """
+        Differential drive example scenario
+        Run this file to try it out
+
+        The first agent has differential drive dynamics.
+        You can control its forward input with the LEFT and RIGHT arrows.
+        You can control its rotation with UP and DOWN.
+
+        The second agent has standard vmas holonomic dynamics.
+        You can control it with WASD
+        You can control its rotation with Q and E.
+
+        """
+        # T
+        self.plot_grid = True
+        self.n_agents = kwargs.pop("n_agents", 2)
+        ScenarioUtils.check_kwargs_consumed(kwargs)
+
+        # Make world
+        world = World(batch_dim, device, substeps=10)
+
+        agent = Agent(
+            name="diff_drive",
+            collide=True,
+            render_action=True,
+            u_range=[1, 1],
+            u_multiplier=[1, 1],
+            dynamics=DiffDrive(world, integration="rk4"),
+            sensors=[
+                Lidar(
+                    world=world,
+                    n_rays=100,
+                    max_range=0.5,
+                    render_color=Color.GRAY,
+                    alpha=0.25,
+                )
+            ],
+        )
+        world.add_agent(agent)
+
+        line = Line(0.5)
+        sphere = Sphere(0.2)
+        box = Box(0.2, 0.2)
+        for i, shp in enumerate([line, sphere, box]):
+            world.add_landmark(
+                Landmark(
+                    name=f"o_{i}",
+                    shape=shp,
+                    collision_filter=lambda e: e.movable,
+                )
+            )
+
+        return world
+
+    def reset_world_at(self, env_index: int = None):
+        ScenarioUtils.spawn_entities_randomly(
+            self.world.agents,
+            self.world,
+            env_index,
+            min_dist_between_entities=0.1,
+            x_bounds=(-1, 1),
+            y_bounds=(-1, 1),
+        )
+        ScenarioUtils.spawn_entities_randomly(
+            self.world.landmarks,
+            self.world,
+            env_index,
+            min_dist_between_entities=0.1,
+            x_bounds=(-1, 1),
+            y_bounds=(-1, 1),
+        )
+
+    def reward(self, agent: Agent):
+        return torch.zeros(self.world.batch_dim)
+
+    def observation(self, agent: Agent):
+        observations = [
+            agent.state.pos,
+            agent.state.vel,
+        ]
+        agent.sensors[0].measure()
+        return torch.cat(
+            observations,
+            dim=-1,
+        )
+
+    def extra_render(self, env_index: int = 0) -> "List[Geom]":
+        from vmas.simulator import rendering
+
+        geoms: List[Geom] = []
+
+        # Agent rotation
+        for agent in self.world.agents:
+            color = Color.BLACK.value
+            line = rendering.Line(
+                (0, 0),
+                (0.1, 0),
+                width=1,
+            )
+            xform = rendering.Transform()
+            xform.set_rotation(agent.state.rot[env_index])
+            xform.set_translation(*agent.state.pos[env_index])
+            line.add_attr(xform)
+            line.set_color(*color)
+            geoms.append(line)
+
+        return geoms
+
+
+if __name__ == "__main__":
+    render_interactively(__file__, control_two_agents=False)

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -101,45 +101,46 @@ class Lidar(Sensor):
     def measure(self):
         dists = []
 
-        start_time = time.perf_counter()
-        for angle in self._angles.unbind(1):
-            dists.append(
-                self._world.cast_ray(
-                    self.agent,
-                    angle + self.agent.state.rot.squeeze(-1),
-                    max_range=self._max_range,
-                    entity_filter=self.entity_filter,
-                )
-            )
-        measurement = torch.stack(dists, dim=1)
-        print(f"LOOP TIME: {time.perf_counter() - start_time}")
+        # start_time = time.perf_counter()
+        # for angle in self._angles.unbind(1):
+        #     dists.append(
+        #         self._world.cast_ray(
+        #             self.agent,
+        #             angle + self.agent.state.rot.squeeze(-1),
+        #             max_range=self._max_range,
+        #             entity_filter=self.entity_filter,
+        #         )
+        #     )
+        # measurement = torch.stack(dists, dim=1)
+        # print(f"LOOP TIME: {time.perf_counter() - start_time}")
 
         a = self._angles
-        start_time = time.perf_counter()
+        # start_time = time.perf_counter()
         dist_test = self._world.cast_rays(
             self.agent,
             a + self.agent.state.rot,
             max_range=self._max_range,
             entity_filter=self.entity_filter,
         )
-        print(f"VEC TIME: {time.perf_counter() - start_time}")
+        # print(f"VEC TIME: {time.perf_counter() - start_time}")
 
         # Define a tolerance for the comparison
-        tolerance = 1e-5
-        differences = torch.abs(dist_test - measurement)
+        # tolerance = 1e-5
+        # differences = torch.abs(dist_test - measurement)
 
         # Find indices where differences exceed the tolerance
-        significant_diffs = torch.nonzero(differences > tolerance)
+        # significant_diffs = torch.nonzero(differences > tolerance)
 
-        if significant_diffs.numel() > 0:
-            print("AssertionError triggered!")
-            for idx in significant_diffs:
-                i, j = idx.tolist()
-                print(f"Difference at index ({i}, {j}):")
-                print(f"  dist_test[{i}, {j}] = {dist_test[i, j]}")
-                print(f"  measurement[{i}, {j}] = {measurement[i, j]}")
-                print(f"  Difference = {differences[i, j]}")
-            raise AssertionError("not all vectors were close!")
+        # if significant_diffs.numel() > 0:
+        #     print("AssertionError triggered!")
+        #     for idx in significant_diffs:
+        #         i, j = idx.tolist()
+        #         print(f"Difference at index ({i}, {j}):")
+        #         print(f"  dist_test[{i}, {j}] = {dist_test[i, j]}")
+        #         print(f"  measurement[{i}, {j}] = {measurement[i, j]}")
+        #         print(f"  Difference = {differences[i, j]}")
+        #     raise AssertionError("not all vectors were close!")
+        measurement = dist_test
         self._last_measurement = measurement
         return measurement
 

--- a/vmas/simulator/sensors.py
+++ b/vmas/simulator/sensors.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import time
 import typing
 from abc import ABC, abstractmethod
 from typing import Callable, List, Tuple, Union
@@ -99,6 +100,8 @@ class Lidar(Sensor):
 
     def measure(self):
         dists = []
+
+        start_time = time.perf_counter()
         for angle in self._angles.unbind(1):
             dists.append(
                 self._world.cast_ray(
@@ -109,6 +112,34 @@ class Lidar(Sensor):
                 )
             )
         measurement = torch.stack(dists, dim=1)
+        print(f"LOOP TIME: {time.perf_counter() - start_time}")
+
+        a = self._angles
+        start_time = time.perf_counter()
+        dist_test = self._world.cast_rays(
+            self.agent,
+            a + self.agent.state.rot,
+            max_range=self._max_range,
+            entity_filter=self.entity_filter,
+        )
+        print(f"VEC TIME: {time.perf_counter() - start_time}")
+
+        # Define a tolerance for the comparison
+        tolerance = 1e-5
+        differences = torch.abs(dist_test - measurement)
+
+        # Find indices where differences exceed the tolerance
+        significant_diffs = torch.nonzero(differences > tolerance)
+
+        if significant_diffs.numel() > 0:
+            print("AssertionError triggered!")
+            for idx in significant_diffs:
+                i, j = idx.tolist()
+                print(f"Difference at index ({i}, {j}):")
+                print(f"  dist_test[{i}, {j}] = {dist_test[i, j]}")
+                print(f"  measurement[{i}, {j}] = {measurement[i, j]}")
+                print(f"  Difference = {differences[i, j]}")
+            raise AssertionError("not all vectors were close!")
         self._last_measurement = measurement
         return measurement
 


### PR DESCRIPTION
Currently, the lidar is a MAJOR bottleneck. It loops over all angles and all entities, so if you want a lidar with a remotely similar amount of rays as a true lidar this takes seconds for each sensor you use in the environment. 

I have optimized it so now we are not looping over each angle and it gives me num_rays x improvement 

Here I included a test with each landmark/ shape type. 
I have a timer in the measurement function (needs to be removed if you agree to accept the PR)
The measurement function is doing both the loop and the vectorized methods to test if they are truly similar. 
I left these in so you can test for a bit yourself. 
Then I will clean it up and we can merge.

With 100 rays, a single agent, 3 objects: 
```
LOOP TIME: 0.06827758200051903
VEC TIME: 0.000823776999823167
```
