### PR TITLE
Fix: correct joint-passage reward function (issue #145)

### DIFF
--- a/vmas/scenarios/joint_passage.py
+++ b/vmas/scenarios/joint_passage.py
@@ -458,11 +458,11 @@ class Scenario(BaseScenario):
                             self.world.get_distance(a, passage)
                             <= self.min_collision_distance
                         ] += self.collision_reward
-                    for wall in self.walls:
-                        self.collision_rew[
-                            self.world.get_distance(a, wall)
-                            <= self.min_collision_distance
-                        ] += self.collision_reward
+                for wall in self.walls:
+                    self.collision_rew[
+                        self.world.get_distance(a, wall)
+                        <= self.min_collision_distance
+                    ] += self.collision_reward
 
             # Joint collisions
             for p in self.passages:


### PR DESCRIPTION
This PR fixes a bug in the `reward()` function of the `joint_passage.py` scenario.

Currently,
for wall in self.walls: 
is inside the for passage in self.passages: loop, 
(possibly unintended)
